### PR TITLE
Non print

### DIFF
--- a/src/com/yetanalytics/pan/errors.clj
+++ b/src/com/yetanalytics/pan/errors.clj
@@ -458,7 +458,8 @@
                                        ::s/problems
                                        first
                                        :path)]
-                    (if-not silent (println error-text))
+                    (if (and error-text (not silent))
+                      (println error-text))
                     {:path error-path
                      :text error-text}))
                 error-list)))

--- a/src/com/yetanalytics/pan/errors.clj
+++ b/src/com/yetanalytics/pan/errors.clj
@@ -107,7 +107,7 @@
 (exp/defmsg ::ctx/is-at-context "key is not JSON-LD keyword")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Value display 
+;; Value display
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn strv
@@ -152,7 +152,7 @@
                                 :print-specs? false}) explain-data))
         formed-str
         (string/replace unformed-str #"(?<=\n)\s+\.\.\.\n" "")]
-    (print formed-str)))
+    formed-str))
 
 ;; TODO Current default-printer function is quite unhelpful in locating errors.
 ;; May look into this again.
@@ -257,7 +257,7 @@
 ;; TODO Possibly make custom error messages for @context errors?
 (defn custom-printer
   "Returns a printer based on the error-type argument. A nil error-type will
-  result in the default Expound printer (except with :print-specs? set to 
+  result in the default Expound printer (except with :print-specs? set to
   false). error-types:
   - id: Duplicate ID errors
   - in-scheme: InScheme property errors
@@ -280,7 +280,7 @@
       #_(exp/custom-printer {:value-str-fn value-str-def :print-specs? false}))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Property ordering in error messages 
+;; Property ordering in error messages
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def property-order
@@ -368,12 +368,12 @@
 ;;
 ;; TODO: Issue #165 has been marked as a bug so it should be fixed at some
 ;; point. When that happens, rework this namespace to rely on Expound's native
-;; error grouping functionality so it doesn't have to do awkward map manips. 
+;; error grouping functionality so it doesn't have to do awkward map manips.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn compare-properties
-  "Get the order of two properties based on how it was listed in the xAPI 
-  Profile spec. Properties not listed in the property-order map will be pushed 
+  "Get the order of two properties based on how it was listed in the xAPI
+  Profile spec. Properties not listed in the property-order map will be pushed
   to the end of the error list and sorted alphabetically.
   - neg number: prop1 comes before prop2
   - pos number: prop1 comes after prop2
@@ -442,26 +442,35 @@
   "Print an Expounded error message using a custom printer. The custom printer
   is determined using the error-type arg; if not supplied, it prints a default
   Expound error message (without the Relevant Specs trace)."
-  [error-map & [error-type]]
+  [error-map & {:keys [error-type silent]}]
   (let [print-fn (custom-printer error-type)]
     (print-fn error-map)))
 
 (defn expound-error-list
   "Sort a list of spec error maps using the value of the :path key."
-  [error-list & [error-type]]
-  (doseq [error error-list]
-    (do (expound-error error error-type) (println))))
+  [error-list & {:keys [error-type silent]}]
+  (into [] (map (fn [error]
+                  (let [error-text (expound-error error
+                                                  :error-type error-type
+                                                  :silent silent)]
+                    (if-not silent (println error-text))
+                    error-text))
+                error-list)))
 
 (defn expound-error-map
   "Regroup an error map into a sorted list of error maps.
   Used to avoid Issue #165 for Expound."
-  [error-map & [error-type]]
-  (-> error-map group-by-in sort-by-path (expound-error-list error-type)))
+  [error-map & {:keys [error-type silent]}]
+  (-> error-map
+      group-by-in
+      sort-by-path
+      (expound-error-list :error-type error-type
+                          :silent silent)))
 
 (defn expound-errors
   "Print errors from profile validation using Expound. Available keys:
   :syntax-errors - Basic syntax validation (always present)
-  :id-errors - Duplicate ID errors 
+  :id-errors - Duplicate ID errors
   :in-scheme-errors - inScheme property validation
   :concept-errors - Concept relation/link errors
   :template-errors - Template relation/link errors
@@ -477,14 +486,28 @@
            pattern-errors
            pattern-cycle-errors
            context-errors
-           context-key-errors]}]
+           context-key-errors
+           silent]}]
   (do
-    (if (some? syntax-errors) (expound-error-map syntax-errors))
-    (if (some? id-errors) (expound-error id-errors "id"))
-    (if (some? in-scheme-errors) (expound-error in-scheme-errors "in-scheme"))
-    (if (some? concept-errors) (expound-error-map concept-errors "edge"))
-    (if (some? template-errors) (expound-error-map template-errors "edge"))
-    (if (some? pattern-errors) (expound-error-map pattern-errors "edge"))
+    (if (some? syntax-errors) (expound-error-map syntax-errors
+                                                 :silent silent))
+    (if (some? id-errors) (expound-error id-errors
+                                         :error-type "id"
+                                         :silent silent))
+    (if (some? in-scheme-errors) (expound-error in-scheme-errors
+                                                :error-type "in-scheme"
+                                                :silent silent))
+    (if (some? concept-errors) (expound-error-map concept-errors
+                                                  :error-type "edge"
+                                                  :silent silent))
+    (if (some? template-errors) (expound-error-map template-errors
+                                                   :error-type "edge"
+                                                   :silent silent))
+    (if (some? pattern-errors) (expound-error-map pattern-errors
+                                                  :error-type "edge"
+                                                  :silent silent))
     ;; Context errors are already in list format
-    (if (some? context-errors) (expound-error-list context-errors))
-    (if (some? context-key-errors) (expound-error-list context-key-errors))))
+    (if (some? context-errors) (expound-error-list context-errors
+                                                   :silent silent))
+    (if (some? context-key-errors) (expound-error-list context-key-errors
+                                                       :silent silent))))

--- a/src/com/yetanalytics/pan/errors.clj
+++ b/src/com/yetanalytics/pan/errors.clj
@@ -449,20 +449,19 @@
 (defn expound-error-list
   "Sort a list of spec error maps using the value of the :path key."
   [error-list & {:keys [error-type silent]}]
-  (into [] (map (fn [error]
-
-                  (let [error-text (expound-error error
-                                                  :error-type error-type
-                                                  :silent silent)
-                        error-path (-> error
-                                       ::s/problems
-                                       first
-                                       :path)]
-                    (if (and error-text (not silent))
-                      (println error-text))
-                    {:path error-path
-                     :text error-text}))
-                error-list)))
+  (mapv (fn [error]
+          (let [error-text (expound-error error
+                                          :error-type error-type
+                                          :silent silent)
+                error-path (-> error
+                               ::s/problems
+                               first
+                               :path)]
+            (if (and error-text (not silent))
+              (println error-text))
+            {:path error-path
+             :text error-text}))
+        error-list))
 
 (defn expound-error-map
   "Regroup an error map into a sorted list of error maps.

--- a/test/com/yetanalytics/pan_test/errors_test.clj
+++ b/test/com/yetanalytics/pan_test/errors_test.clj
@@ -202,30 +202,6 @@
                 (mapv #(-> % ::s/problems first :via last)))
            [::id/in-scheme ::id/in-scheme]))))
 
-(comment
-  (require '[com.yetanalytics.pan.errors :as e])
-  (require '[com.yetanalytics.pan.objects.profile :as p])
-  (def good-profile-1
-    {:id "https://w3id.org/xapi/catch"
-     :type "Profile"
-     :prefLabel {"en" "Catch"}
-     :definition {"en" "The profile for the trinity education application CATCH"}
-     :_context "https://w3id.org/xapi/profiles/context"
-     :versions [{:id "https://w3id.org/xapi/catch/v1"
-                 :generatedAtTime "2017-12-22T22:30:00-07:00"}]
-     :author {:url "https://www.yetanalytics.io"
-              :type "Organization"
-              :name "Yet Analytics"}
-     :conformsTo "https://w3id.org/xapi/profiles#1.0"})
-  (def bad-profile-1b (assoc good-profile-1
-                             :id "not an id"
-                             :type "FooBar"))
-  (let [errormsg (with-out-str (e/expound-error-map (p/validate bad-profile-1b)))]
-    (println "here is the output")
-    (println errormsg))
-  )
-
-
 (deftest expound-test
   (testing "error/expound-errors error messages"
     (is (= (with-out-str

--- a/test/com/yetanalytics/pan_test/errors_test.clj
+++ b/test/com/yetanalytics/pan_test/errors_test.clj
@@ -202,6 +202,30 @@
                 (mapv #(-> % ::s/problems first :via last)))
            [::id/in-scheme ::id/in-scheme]))))
 
+(comment
+  (require '[com.yetanalytics.pan.errors :as e])
+  (require '[com.yetanalytics.pan.objects.profile :as p])
+  (def good-profile-1
+    {:id "https://w3id.org/xapi/catch"
+     :type "Profile"
+     :prefLabel {"en" "Catch"}
+     :definition {"en" "The profile for the trinity education application CATCH"}
+     :_context "https://w3id.org/xapi/profiles/context"
+     :versions [{:id "https://w3id.org/xapi/catch/v1"
+                 :generatedAtTime "2017-12-22T22:30:00-07:00"}]
+     :author {:url "https://www.yetanalytics.io"
+              :type "Organization"
+              :name "Yet Analytics"}
+     :conformsTo "https://w3id.org/xapi/profiles#1.0"})
+  (def bad-profile-1b (assoc good-profile-1
+                             :id "not an id"
+                             :type "FooBar"))
+  (let [errormsg (with-out-str (e/expound-error-map (p/validate bad-profile-1b)))]
+    (println "here is the output")
+    (println errormsg))
+  )
+
+
 (deftest expound-test
   (testing "error/expound-errors error messages"
     (is (= (with-out-str
@@ -242,7 +266,7 @@
                 "\n"
                 "")))
     (is (= (with-out-str
-             (e/expound-error (id/validate-ids bad-profile-2b) "id"))
+             (e/expound-error (id/validate-ids bad-profile-2b) :error-type "id"))
            (str "-- Spec failed --------------------\n"
                 "\n"
                 "Duplicate id: \"https://w3id.org/xapi/catch/v1\"\n"
@@ -260,7 +284,7 @@
                 "-------------------------\n"
                 "Detected 2 errors\n")))
     (is (= (with-out-str
-             (e/expound-error (id/validate-in-schemes bad-profile-2c) "in-scheme"))
+             (e/expound-error (id/validate-in-schemes bad-profile-2c) :error-type "in-scheme"))
            (str "-- Spec failed --------------------\n"
                 "\n"
                 "Invalid inScheme: \"https://foo.org/invalid\"\n"
@@ -284,7 +308,7 @@
                 "-------------------------\n"
                 "Detected 2 errors\n")))
     (is (= (with-out-str
-             (e/expound-error-map (t/explain-graph (t/create-graph [] (:templates bad-profile-2d))) "edge"))
+             (e/expound-error-map (t/explain-graph (t/create-graph [] (:templates bad-profile-2d))) :error-type "edge"))
            (str "-- Spec failed --------------------\n"
                 "\n"
                 "Invalid verb identifier:\n"
@@ -306,7 +330,6 @@
                 "\n"
                 "-------------------------\n"
                 "Detected 1 error\n"
-                "\n"
                 "-- Spec failed --------------------\n"
                 "\n"
                 "Invalid attachmentUsageType identifier:\n"
@@ -327,10 +350,9 @@
                 "linked concept or template does not exist\n"
                 "\n"
                 "-------------------------\n"
-                "Detected 1 error\n"
-                "\n")))
+                "Detected 1 error\n")))
     (is (= (with-out-str
-             (e/expound-error-map (t/explain-graph (t/create-graph [] (:templates bad-profile-2e))) "edge"))
+             (e/expound-error-map (t/explain-graph (t/create-graph [] (:templates bad-profile-2e))) :error-type "edge"))
            (str "-- Spec failed --------------------\n"
                 "\n"
                 "Invalid verb identifier:\n"
@@ -352,7 +374,6 @@
                 "\n"
                 "-------------------------\n"
                 "Detected 1 error\n"
-                "\n"
                 "-- Spec failed --------------------\n"
                 "\n"
                 "Invalid attachmentUsageType identifier:\n"
@@ -373,11 +394,10 @@
                 "object cannot refer to itself\n"
                 "\n"
                 "-------------------------\n"
-                "Detected 1 error\n"
-                "\n")))
+                "Detected 1 error\n")))
     (is (= (with-out-str
              (e/expound-error
-              (pt/explain-graph-cycles (pt/create-graph (:templates bad-profile-2f) (:patterns bad-profile-2f))) "scc"))
+              (pt/explain-graph-cycles (pt/create-graph (:templates bad-profile-2f) (:patterns bad-profile-2f))) :error-type "scc"))
            (str "-- Spec failed --------------------\n"
                 "\n"
                 "Cycle detected involving the following nodes:\n"
@@ -390,7 +410,7 @@
                 "Detected 1 error\n")))
     (is (= (with-out-str
              (e/expound-error
-              (pt/explain-graph (pt/create-graph (:templates bad-profile-2g) (:patterns bad-profile-2g))) "edge"))
+              (pt/explain-graph (pt/create-graph (:templates bad-profile-2g) (:patterns bad-profile-2g))) :error-type "edge"))
            (str "-- Spec failed --------------------\n"
                 "\n"
                 "Invalid oneOrMore identifier:\n"


### PR DESCRIPTION
This allows a key to be passed to expound fns which stops it from raw printing the result and instead returns a data structure with the path and the full error text for use elsewhere