### PR TITLE
Context overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Arguments may be supplied for different levels of validation strictness, which a
 
 Other keyword arguments include:
 - `:external-profiles` - Extra Profiles from which to reference Concepts, Statement Templates, and Patterns from. Unlike the Profiles passed into `validate-profile-coll`, these Profiles are not validated (though will be treated as part of the same scope in terms of ID distinctiveness validation).
+- `:external-contexts` - Extra `@context` values (other than the xAPI Profile and Activity contexts) that `@context` IRIs in `profile` can reference during context validation. During multi-profile validation, all Profiles refer to the same global `:external-contexts` map. Default `{}`.
 - `:print-errs?` - Print validation errors out if true; otherwise return spec error data (or nil, if the profile is valid) without printing. Default `true`.
 
 Besides validating whole Profiles, you can also use library methods and specs to validate parts of Profiles, such as individual  Concepts, Templates and Patterns).

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Other keyword arguments include:
 - `:external-contexts` - Extra `@context` values (other than the xAPI Profile and Activity contexts) that `@context` IRIs in `profile` can reference during context validation. During multi-profile validation, all Profiles refer to the same global `:external-contexts` map. Default `{}`.
 - `:print-errs?` - Print validation errors out if true; otherwise return spec error data (or nil, if the profile is valid) without printing. Default `true`.
 
+The `get-external-iris` function is provided in the API in order to retrieve IRI values that refer to external objects, JSON-LD contexts, etc. (i.e. objects that do _not_ exist in the Profile). This allows the user to more easily retrieve external Profiles and contexts in their application from the Internet or their data store.
+
 Besides validating whole Profiles, you can also use library methods and specs to validate parts of Profiles, such as individual  Concepts, Templates and Patterns).
 
 ## TODO

--- a/resources/context/profile-context.json
+++ b/resources/context/profile-context.json
@@ -213,7 +213,8 @@
             "@container": "@set"
         },
         "scopeNote": {
-            "@id": "skos:scopeNote"
+            "@id": "skos:scopeNote",
+            "@container": "@language"
         },
         "primary": {
             "@id": "profile:primary",

--- a/src/main/com/yetanalytics/pan.cljc
+++ b/src/main/com/yetanalytics/pan.cljc
@@ -41,8 +41,8 @@
 (defn- find-context-errors
   [profile ?extra-contexts-map]
   (if ?extra-contexts-map
-    (context/validate-contexts profile ?extra-contexts-map)
-    (context/validate-contexts profile)))
+    {:context-errors (context/validate-contexts profile ?extra-contexts-map)}
+    {:context-errors (context/validate-contexts profile)}))
 
 (defn validate-profile
   "Validate `profile` from the top down, printing or returning errors

--- a/src/main/com/yetanalytics/pan.cljc
+++ b/src/main/com/yetanalytics/pan.cljc
@@ -8,7 +8,7 @@
             [com.yetanalytics.pan.errors :as errors]))
 
 (defn get-external-iris
-  "Return a map of keys to IRI collections, where the IRIs reference
+  "Return a map of keys to sets of IRIs, where the IRIs reference
    objects that do not exist in `profile`. Values include IRIs
    from Concepts, Statement Templates, and Patterns as well as
    \"@context\" IRI values."

--- a/src/main/com/yetanalytics/pan.cljc
+++ b/src/main/com/yetanalytics/pan.cljc
@@ -7,6 +7,19 @@
             [com.yetanalytics.pan.context :as context]
             [com.yetanalytics.pan.errors :as errors]))
 
+(defn get-external-iris
+  "Return a map of keys to IRI collections, where the IRIs reference
+   objects that do not exist in `profile`. Values include IRIs
+   from Concepts, Statement Templates, and Patterns as well as
+   \"@context\" IRI values."
+  [profile]
+  (let [iris-m (merge (concept/get-external-iris profile)
+                      (template/get-external-iris profile)
+                      (pattern/get-external-iris profile))]
+    (if-some [ctx-iris (not-empty (context/get-context-iris profile))]
+      (assoc iris-m :_context ctx-iris)
+      iris-m)))
+
 (defn- find-syntax-errors
   [profile]
   {:syntax-errors (profile/validate profile)})

--- a/src/main/com/yetanalytics/pan.cljc
+++ b/src/main/com/yetanalytics/pan.cljc
@@ -60,7 +60,11 @@
                          expand to absolute IRIs using RDF contexts. Default
                          `false.`
    - `:extra-profiles` Extra profiles from which Concepts, Templates, and
-                         Patterns can be referenced from. Default `[]`."
+                         Patterns can be referenced from. Default `[]`.
+   - `:extra-contexts` Extra \"@context\" values (other than the xAPI Profile
+                         and Activity contexts) that \"@context\" IRIs in
+                         `profile` can reference during context validation.
+                         Default `{}`."
   [profile & {:keys [syntax?
                      ids?
                      relations?
@@ -98,8 +102,9 @@
   "Like `validate-profile`, but takes a `profile-coll` instead of a
    single Profile. Each Profile can reference objects in other Profiles
    (as well as those in `:extra-profiles`) and must not share object
-   IDs with those in other Profiles. Keyword arguments are the same as
-   in `validate-profile`."
+   IDs with those in other Profiles. During context validation, all
+   Profiles reference the global `:extra-contexts` map. Keyword
+   arguments are the same as in `validate-profile`."
   [profile-coll & {:keys [syntax?
                           ids?
                           relations?

--- a/src/main/com/yetanalytics/pan/context.cljc
+++ b/src/main/com/yetanalytics/pan/context.cljc
@@ -30,9 +30,7 @@
   {"https://w3id.org/xapi/profiles/context"          profile-context
    "https://w3id.org/xapi/profiles/activity-context" activity-context})
 
-;; NOT all JSON-LD keywords, but just ones that are commonly aliased
-;; in contexts.
-(def jsonld-keywords #{"@id" "@type"})
+(s/def ::jsonld-keyword #{"@id" "@type"})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Context Spec
@@ -56,7 +54,7 @@
 
 (s/def ::context-value
   (s/or
-   :keyword jsonld-keywords
+   :keyword ::jsonld-keyword
    :iri ::ax/iri
    :simple-term-def :context.term-def/_id
    :expanded-term-def (s/keys :req-un [:context.term-def/_id]
@@ -176,10 +174,12 @@
   (and (keyword? x)
        (->> x name (re-matches #"_LANGTAG_.*"))))
 
+(s/def ::language-tag lang-tag?)
+
 (s/def ::expanded-key
   (s/or :iri ::ax/iri
-        :keyword jsonld-keywords
-        :lang-tag lang-tag?))
+        :keyword ::jsonld-keyword
+        :lang-tag ::language-tag))
 
 (s/def ::expanded-key-profile
   (s/or :scalar (comp not coll?)
@@ -190,7 +190,8 @@
   "Filter such that non-leaf specs do not clutter the error data map."
   [problems]
   (filter (fn [{:keys [via]}]
-            (#{::expanded-key ::ax/iri ::ax/string} (last via)))
+            (#{::language-tag ::jsonld-keyword ::ax/iri ::ax/string}
+             (last via)))
           problems))
 
 (defn- validate-contexts*

--- a/src/main/com/yetanalytics/pan/context.cljc
+++ b/src/main/com/yetanalytics/pan/context.cljc
@@ -453,3 +453,38 @@
   (->> profile
        (expand-profile-keys contexts-map {})
        (s/explain-data ::expanded-key-profile)))
+
+(def context-keywords
+  #{:_base :_import :_language :_propagate :_protected :_type :_version :_vocab})
+
+(s/def :context.term-def/id (partial re-matches #".*:.*"))
+
+(s/def ::_base ::ax/iri)
+(s/def ::_import ::ax/iri)
+(s/def ::_language ::ax/language-tag)
+(s/def ::_propagate ::ax/boolean)
+(s/def ::_protected ::ax/boolean)
+(s/def ::_type (s/keys :req-un [::_container]))
+(s/def ::_version #{1.1})
+(s/def ::_vocab ::ax/iri)
+
+;; Currently only @vocab value is used
+;; TODO: Apply other context properties
+(def context-spec
+  (s/and (s/keys :opt-un [::_vocab])
+   (s/conformer #(apply dissoc % context-keywords))
+         (s/map-of
+          keyword?
+          (s/or :iri
+                ::ax/iri
+                :simple-term-def
+                :context.term-def/id
+                :expanded-term-def
+                (s/keys :req-un [:context.term-def/id])))))
+
+(s/def ::_context
+  (s/or :iri ::ax/iri
+        :inline context-spec
+        :array (s/coll-of (s/or :iri ::ax/iri
+                                :inline context-spec)
+                          :min-count 1)))

--- a/src/main/com/yetanalytics/pan/context.cljc
+++ b/src/main/com/yetanalytics/pan/context.cljc
@@ -48,21 +48,23 @@
 (s/def ::_version #{1.1})
 (s/def ::_vocab ::ax/iri)
 
+(s/def ::context-value
+  (s/or
+   :keyword #{"@id" "@type"}
+   :iri ::ax/iri
+   :simple-term-def :context.term-def/_id
+   :expanded-term-def (s/keys :req-un [:context.term-def/_id]
+                              :opt-un [:context.term-def/_container])))
+
 (def context-spec
-  (s/map-of
-   keyword?
-   (s/or
-    :keyword #{"@id" "@type"}
-    :iri ::ax/iri
-    :simple-term-def :context.term-def/_id
-    :expanded-term-def (s/keys :req-un [:context.term-def/_id]
-                               :opt-un [:context.term-def/_container]))))
+  (s/map-of keyword? ::context-value))
 
 (s/def ::_context
   (s/or :iri ::ax/iri
         :inline context-spec
         :array (s/coll-of (s/or :iri ::ax/iri
                                 :inline context-spec)
+                          :kind vector?
                           :min-count 1)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/main/com/yetanalytics/pan/context.cljc
+++ b/src/main/com/yetanalytics/pan/context.cljc
@@ -1,9 +1,7 @@
 (ns com.yetanalytics.pan.context
   (:require [clojure.spec.alpha :as s]
             [clojure.string :as string]
-            [clojure.zip :as zip]
-            [com.yetanalytics.pan.axioms :as ax]
-            [com.yetanalytics.pan.utils.spec :as util])
+            [com.yetanalytics.pan.axioms :as ax])
   #?(:clj (:require [com.yetanalytics.pan.utils.resources
                      :refer [read-json-resource]])
      :cljs (:require-macros [com.yetanalytics.pan.utils.resources
@@ -19,358 +17,92 @@
 ;; validation may be added in a later iteration.
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Parse context 
+;; Inits 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def profile-context
-  (read-json-resource "context/profile-context.json" "at/"))
+  (:_context (read-json-resource "context/profile-context.json" "_")))
 
 (def activity-context
-  (read-json-resource "context/activity-context.json" "at/"))
-
-;; (defn- uri->context*
-;;   "Get a context and parse it from JSON to EDN.
-;;    If a @context is one of two contexts given by the profile spec, call them
-;;    from local resources."
-;;   [context]
-;;   (case context
-;;     "https://w3id.org/xapi/profiles/context"
-;;     profile-context
-;;     "https://w3id.org/xapi/profiles/activity-context"
-;;     activity-context
-;;     ;; TODO get other contexts from the Internet; currently throws exception
-;;     (throw (ex-info "Unable to read from URI"
-;;                     {:type ::unknown-context-uri
-;;                      :url   context}))))
-
-;; (defn uri->context
-;;   "Get a raw context, then parse it from JSON to EDN.
-;;   Return the JSON object given by the @context key"
-;;   [context-uri]
-;;   (-> context-uri uri->context* :at/context))
+  (:_context (read-json-resource "context/activity-context.json" "_")))
 
 (def default-context-map
   {"https://w3id.org/xapi/profiles/context"          profile-context
    "https://w3id.org/xapi/profiles/activity-context" activity-context})
 
-(defn uri->context
-  [context-map context-uri]
-  (if-some [context-val (get context-map context-uri)]
-    (:at/context context-val)
-    {}))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Validate context 
+;; Context Spec
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; JSON-LD node objects may be aliased to the following keywords.
-;; This spec checks if a @context key is an alias to a keyword value.
-;; See section 6.2: Node Objects in the JSON-LD grammar.
-(s/def ::context-keyword
-  #{"@context" "@id" "@graph" "@nest" "@type" "@reverse" "@index"})
+(s/def :context.term-def/_id (s/and string? (partial re-matches #".*:.*")))
+(s/def :context.term-def/_container #{"@list" "@set" "@language"})
 
-;; Regular expressions
-;; Note: Forward slash is not escaped in JS regex
-(def gen-delims-regex
-  #?(:clj #".*(?:\:|\/|\?|\#|\[|\]|\@)$"
-     :cljs #".*(?:\:|/|\?|\#|\[|\]|\@)$"))
+;; Unimplemented context keyword specs, but kept here for reference
+(s/def ::_base ::ax/iri)
+(s/def ::_import ::ax/iri)
+(s/def ::_language ::ax/language-tag)
+(s/def ::_propagate ::ax/boolean)
+(s/def ::_protected ::ax/boolean)
+(s/def ::_container #{"@set"})
+(s/def ::_type (s/keys :req-un [::_container]))
+(s/def ::_version #{1.1})
+(s/def ::_vocab ::ax/iri)
 
-(def prefix-regex #"(.*\:)")
+(def context-spec
+  (s/map-of
+   keyword?
+   (s/or
+    :keyword #{"@id" "@type"}
+    :iri ::ax/iri
+    :simple-term-def :context.term-def/_id
+    :expanded-term-def (s/keys :req-un [:context.term-def/_id]
+                               :opt-un [:context.term-def/_container]))))
 
-;; JSON-LD 1.1 prefixes may be a simple term definition that ends in a URI
-;; general delimiter char or an expanded term definition with @prefix set to
-;; true. See section 4.4: Compact IRIs in the JSON-LD grammar.
-(s/def ::context-prefix
-  (s/or :simple-term-def
-        (s/and ::ax/iri #(->> % (re-matches gen-delims-regex) some?))
-        :expanded-term-def
-        (s/and map? #(-> % :prefix true?))))
-
-(defn collect-prefixes
-  "Returns all the prefixes in a context."
-  [context]
-  (reduce-kv (fn [accum k v]
-               (if (s/valid? ::context-prefix v) (assoc accum k v) accum))
-             {}
-             context))
-
-(defn compact-iri?
-  "Validates whether this is a compact iri that has a valid prefix."
-  [prefixes value]
-  (and (string? value)
-       (contains? prefixes (-> value (string/split #"\:") first keyword))))
-
-(defn context-map?
-  "Validates whether this is a JSON object with a @id that has a valid prefix."
-  [prefixes value]
-  (and (map? value)
-       (compact-iri? prefixes (:at/id value))))
-
-;; TODO: Add "!" due to side effect on spec registry
-(defn validate-context
-  [context]
-  (let [prefixes (collect-prefixes context)]
-    ;; Hack the global spec registry by redefining these specs w/ new prefixes
-    (s/def ::simple-term-def (partial compact-iri? prefixes))
-    (s/def ::expanded-term-def (partial context-map? prefixes))
-    (s/def ::jsonld-context (s/map-of
-                             any?
-                             (s/or :keyword ::context-keyword
-                                   :prefix  ::context-prefix
-                                   :simple-term-def   ::simple-term-def
-                                   :expanded-term-def ::expanded-term-def)))
-    (s/explain-data ::jsonld-context context)))
+(s/def ::_context
+  (s/or :iri ::ax/iri
+        :inline context-spec
+        :array (s/coll-of (s/or :iri ::ax/iri
+                                :inline context-spec)
+                          :min-count 1)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Validate profile against context 
+;; Context Expansion and Validation
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; Exclude language maps or inline @context maps as node children
-(def excluded-props
-  #{:prefLabel :definition :scopeNote :name :description :_context})
-
-(defn- children
-  "Zipper function for returning the children at a location in a Profile.
-  Returns nil if there are no children at the location."
-  [node]
-  (not-empty
-   (reduce-kv
-    (fn [accum k v]
-      (cond
-        ;; Objects
-        (and (map? v) (not (excluded-props k)))
-        (conj accum v)
-        ;; Arrays of objects
-        (and (vector? v) (every? map? v))
-        (concat accum v)
-        ;; Don't consider anything else as children
-        :else
-        accum))
-    '()
-    node)))
-
-(defn profile-to-zipper
-  "Create a zipper from a profile structure."
-  [profile]
-  (zip/zipper map? children nil profile))
-
-(defn pop-context
-  "Pop the last-added context if the path is not located at the current
-  location nor a parent of the current location."
-  [context-stack location]
-  (if-not (util/subvec? (-> context-stack peek :path)
-                        (-> location zip/path vec))
-    (pop context-stack)
-    context-stack))
-
-(defn pop-contexts
-  "Repeatedly pop the latest-added contexts until the context is located at
-  the current location or a parent thereof."
-  [context-stack location]
-  (loop [old-stack context-stack]
-    (if (empty? old-stack)
-      old-stack
-      (let [new-stack (pop-context old-stack location)]
-        (if (= new-stack old-stack)
-          new-stack
-          (recur new-stack))))))
-
-(defn push-context
-  "If there exists a @context key at the current node, add it to the stack.
-  Recall that @context may be either a URI string or an array of URIs."
-  [context-map context-stack location]
-  (let [curr-path (-> location zip/path vec)
-        context-val (-> location zip/node :_context)]
-    (letfn [(push-context*
-              [context-stack context]
-              (if-let [errors (validate-context context)]
-                (conj context-stack {:context nil
-                                     :errors  errors
-                                     :path    curr-path})
-                (conj context-stack {:context context
-                                     :errors  nil
-                                     :path    curr-path})))]
-      (cond
-        ;; @context is URI valued
-        (s/valid? ::ax/iri context-val)
-        (push-context* context-stack (uri->context context-map context-val))
-        ;; @context is array valued
-        (s/valid? ::ax/array-of-iri context-val)
-        (reduce push-context* context-stack (map (partial uri->context context-map) context-val))
-        ;; @context is inline (not allowed by spec, but good for debug)
-        (map? context-val)
-        (push-context* context-stack context-val)
-        ;; No @context key at this location
-        (nil? context-val)
-        context-stack
-        :else
-        (throw (ex-info "Unknown @context value"
-                        {:type  ::unknown-context-val
-                         :value context-val}))))))
-
-(defn update-context-errors
-  "Update the list of context errors if a new erroneous context had been
-  added to the stack."
-  [old-stack new-stack context-errors]
-  (if (not= old-stack new-stack)
-    (conj context-errors (-> new-stack peek :errors))
-    context-errors))
-
-(defn search-contexts
-  "Given a key, search in all the contexts in the stack for it. Return true
-  if the key is found, false otherwise (as that indicates that the key cannot
-  be expanded to an IRI)."
-  [contexts k]
-  (loop [context-stack contexts]
-    (if (empty? context-stack)
-      false ;; We searched through all the contexts
-      (let [curr (peek context-stack)]
-        (if (-> curr :context (contains? k))
-          true ;; We found the key at the curr context!
-          (recur (pop context-stack)))))))
-
-;; List of keywords taken from Section 1.7 of the JSON-LD spec.
-(s/def ::keyword-key
-  #{:_context
-    :_id
-    :_type
-    :_base
-    :_container
-    :_graph
-    :_index
-    :_language
-    :_list
-    :_nest
-    :_none
-    :_prefix
-    :_reverse
-    :_set
-    :_value
-    :_version
-    :_vocab})
-
-;; At this point all @ signs are replaced by underscores
-;; TODO: Add "!" to denote side effect
-(defn validate-keys
-  [contexts curr-node]
-  ;; Bind key to registry as side effect.
-  (s/def ::iri-key
-    (partial search-contexts contexts))
-  (s/def ::jsonld-node
-    (s/map-of (s/or :iri ::iri-key :keyword ::keyword-key) any?))
-  (s/explain-data ::jsonld-node curr-node))
-
-(defn update-profile-errors
-  [contexts curr-node profile-errors]
-  (let [new-errors (validate-keys contexts curr-node)]
-    (if (some? new-errors)
-      (conj profile-errors new-errors)
-      profile-errors)))
-
-(defn- error-seq->map
-  "Returns the combined error map, or nil if `error-seq` is empty.
-   Updates `:in` to reflect conslidated values."
-  [spec-kw error-seq]
-  (when (not-empty error-seq)
-    (-> (reduce
-         (fn [{index :index :as acc}
-              {probs ::s/problems
-               value ::s/value}]
-           (let [probs' (map (fn [p] (update p :in #(into [index] %))) probs)]
-             (-> acc
-                 (update ::s/problems concat probs')
-                 (update ::s/value conj value)
-                 (update :index inc))))
-         {::s/problems '()
-          ::s/spec     spec-kw
-          ::s/value    '()
-          :index       0}
-         error-seq)
-        (dissoc :index)
-        (update ::s/value (comp vec reverse)))))
-
-(defn- validate-contexts*
-  [context-map profile]
-  (loop [profile-loc (profile-to-zipper profile)
-         context-stack []
-         ;; For contexts themselves that are bad
-         context-errors '()
-         ;; When the profile doesn't follow the context 
-         profile-errors '()]
-    (if-not (zip/end? profile-loc)
-      (let [curr-node (zip/node profile-loc)
-            popped-stack (pop-contexts context-stack profile-loc)
-            pushed-stack (push-context context-map context-stack profile-loc)]
-        (if (-> pushed-stack peek :context nil?)
-          ;; If latest context is erroneous
-          (let [new-cerrors (update-context-errors popped-stack
-                                                   pushed-stack
-                                                   context-errors)]
-            (recur (zip/next profile-loc)
-                   pushed-stack
-                   new-cerrors
-                   profile-errors))
-          ;; If latest context is valid => validate map keys
-          (let [new-perrors (update-profile-errors pushed-stack
-                                                   curr-node
-                                                   profile-errors)]
-            (recur (zip/next profile-loc)
-                   pushed-stack
-                   context-errors
-                   new-perrors))))
-      (let [context-err-seq (filter some? context-errors)
-            profile-err-seq (filter some? profile-errors)
-            context-err-map (error-seq->map ::jsonld-context context-err-seq)
-            profile-err-map (error-seq->map ::jsonld-node profile-err-seq)]
-        {:context-errors     context-err-map
-         :context-key-errors profile-err-map}))))
-
-(defn validate-contexts
-  "Validate all the contexts in a Profile."
-  ([profile]
-   (validate-contexts* default-context-map
-                       profile))
-  ([profile extra-context-map]
-   (validate-contexts* (merge default-context-map extra-context-map)
-                       profile)))
-
-;;;;;;;;;;;
-
-(defn expand-compact-iri
+(defn- expand-compact-iri
   [context compact-iri]
   (when-some [[_ pre post] (re-matches #"(.*):(.*)" compact-iri)]
-    (when-some [exp-pre (get context pre)]
+    (when-some [exp-pre (get context (keyword pre))]
       (str exp-pre post))))
 
-(defn expand-key
+(defn- expand-key
   [context k]
-  (let [kname (name k)]
-    (cond
+  (cond
       ;; compact or expanded IRI
-      (or (s/valid? ::ax/iri kname) (string/includes? kname ":"))
-      (or (expand-compact-iri context kname)
-          kname)
+    (or (s/valid? ::ax/iri k)
+        (and (string? k) (string/includes? k ":")))
+    (or (expand-compact-iri context k)
+        k)
       ;; simple or expanded term definition
-      (contains? context kname)
-      (let [term-def (get context kname)]
-        (or (and (string? term-def)
-                 (expand-compact-iri context term-def))
-            (and (map? term-def)
-                 (expand-compact-iri context (:_id term-def)))
-            ;; fail
-            kname))
-      ;; @vocab IRI prefix
-      (:_vocab context)
-      (str (:_vocab context) kname)
+    (contains? context k)
+    (let [term-def (get context k)]
+      (or (and (string? term-def)
+               (first (re-matches #"(@.*)" term-def)))
+          (and (string? term-def)
+               (expand-compact-iri context term-def))
+          (and (map? term-def)
+               (expand-compact-iri context (:_id term-def)))
+          ;; fail
+          k))
       ;; fail
-      :else
-      kname)))
+    :else
+    k))
 
-(defn lang-map-key?
+(defn- lang-map-key?
   [context k]
   (let [term-def (get context k)]
     (boolean (and (map? term-def)
-                  (#{"@language"} (get :_container term-def))))))
+                  (#{"@language"} (:_container term-def))))))
 
 (defn- new-context
   [contexts-map context]
@@ -388,7 +120,7 @@
                     {:type    ::invalid-context
                      :context context}))))
 
-(defn- expand-profile-keys
+(defn expand-profile-keys*
   [contexts-map context profile]
   (let [context* (if-some [ctx (some->> profile
                                         :_context
@@ -400,22 +132,36 @@
                        v* (cond
                             ;; Need to treat language maps specially
                             ;; Otherwise they'd be treated as node objects
-                            (lang-map-key? context k)
-                            (mapv (fn [[ltag lval]]
-                                    {:_language ltag :_value lval})
-                                  v)
+                            (lang-map-key? context* k)
+                            (into {}
+                                  (map (fn [[ltag lval]]
+                                         [(keyword (str "_LANGTAG_" (name ltag)))
+                                          lval])
+                                       v))
                             (map? v)
-                            (expand-profile-keys contexts-map context* v)
-                            (seq? v)
-                            (mapv (partial expand-profile-keys
-                                           contexts-map
-                                           context*)
+                            (expand-profile-keys* contexts-map
+                                                  context*
+                                                  v)
+                            (coll? v)
+                            (mapv (fn [x]
+                                    (if (map? x)
+                                      (expand-profile-keys*
+                                       contexts-map
+                                       context*
+                                       x)
+                                      x))
                                   v)
                             :else
                             v)]
                    (assoc m k* v*)))
                {}
                (dissoc profile :_context))))
+
+(defn expand-profile-keys
+  ([profile]
+   (expand-profile-keys* default-context-map {} profile))
+  ([profile contexts-map]
+   (expand-profile-keys* (merge default-context-map contexts-map) {} profile)))
 
 ;; All JSON-LD keywords except those exclusive to context maps
 ;; https://www.w3.org/TR/json-ld11/#keywords
@@ -438,7 +184,9 @@
 
 (s/def ::expanded-key
   (s/or :iri ::ax/iri
-        :keyword jsonld-keywords))
+        :keyword #{"@id" "@type"}
+        :lang-tag (s/and keyword?
+                         #(->> % name (re-matches #"_LANGTAG_.*")))))
 
 (s/def ::expanded-key-profile
   (s/map-of ::expanded-key
@@ -446,45 +194,12 @@
                   :array (s/coll-of ::expanded-key-profile)
                   :scalar any?)))
 
-(defn validate-contexts-2
+(defn validate-contexts
   "Validate that all keys in `profile` are able to be expanded into IRIs
    using \"@context\" maps. NOTE: Does not attempt to validate the values."
-  [contexts-map profile]
-  (->> profile
-       (expand-profile-keys contexts-map {})
-       (s/explain-data ::expanded-key-profile)))
-
-(def context-keywords
-  #{:_base :_import :_language :_propagate :_protected :_type :_version :_vocab})
-
-(s/def :context.term-def/id (partial re-matches #".*:.*"))
-
-(s/def ::_base ::ax/iri)
-(s/def ::_import ::ax/iri)
-(s/def ::_language ::ax/language-tag)
-(s/def ::_propagate ::ax/boolean)
-(s/def ::_protected ::ax/boolean)
-(s/def ::_type (s/keys :req-un [::_container]))
-(s/def ::_version #{1.1})
-(s/def ::_vocab ::ax/iri)
-
-;; Currently only @vocab value is used
-;; TODO: Apply other context properties
-(def context-spec
-  (s/and (s/keys :opt-un [::_vocab])
-   (s/conformer #(apply dissoc % context-keywords))
-         (s/map-of
-          keyword?
-          (s/or :iri
-                ::ax/iri
-                :simple-term-def
-                :context.term-def/id
-                :expanded-term-def
-                (s/keys :req-un [:context.term-def/id])))))
-
-(s/def ::_context
-  (s/or :iri ::ax/iri
-        :inline context-spec
-        :array (s/coll-of (s/or :iri ::ax/iri
-                                :inline context-spec)
-                          :min-count 1)))
+  ([profile]
+   (->> (expand-profile-keys profile)
+        (s/explain-data ::expanded-key-profile)))
+  ([profile contexts-map]
+   (->> (expand-profile-keys profile contexts-map)
+        (s/explain-data ::expanded-key-profile))))

--- a/src/main/com/yetanalytics/pan/errors.cljc
+++ b/src/main/com/yetanalytics/pan/errors.cljc
@@ -145,7 +145,7 @@
 ;; Context spec messages
 
 (exp/defmsg ::ctx/_context
-  "should be a valid IRI or inline context")
+  "should be a valid inline context")
 (exp/defmsg ::ctx/expanded-key
   "should be a JSON-LD keyword or language tag")
 

--- a/src/main/com/yetanalytics/pan/errors.cljc
+++ b/src/main/com/yetanalytics/pan/errors.cljc
@@ -146,8 +146,8 @@
 
 (exp/defmsg ::ctx/_context
   "should be a valid inline context")
-(exp/defmsg ::ctx/expanded-key
-  "should be a JSON-LD keyword or language tag")
+(exp/defmsg ::ctx/language-tag
+  "should be a language tag")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Property orderings

--- a/src/main/com/yetanalytics/pan/errors.cljc
+++ b/src/main/com/yetanalytics/pan/errors.cljc
@@ -140,19 +140,8 @@
 
 ;; Context spec messages
 
-(exp/defmsg ::ctx/context-keyword
-  "should be a JSON-LD context keyword")
-(exp/defmsg ::ctx/context-prefix
-  "should be a JSON-LD prefix")
-(exp/defmsg ::ctx/simple-term-def
-  "should be a simple term definition with a valid prefix")
-(exp/defmsg ::ctx/expanded-term-def
-  "should be an expanded term definition with a valid prefix")
-
-(exp/defmsg ::ctx/iri-key
-  "should be expandable into an absolute IRI")
-(exp/defmsg ::ctx/keyword-key
-  "should be a JSON-LD keyword")
+(exp/defmsg ::ctx/expanded-key
+  "should have expanded to an IRI or a JSON-LD keyword.")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Property orderings

--- a/src/main/com/yetanalytics/pan/errors.cljc
+++ b/src/main/com/yetanalytics/pan/errors.cljc
@@ -56,6 +56,10 @@
   "should not use recommended activity type on a Result Extension")
 (exp/defmsg ::act/activityDefinition
   "should be a valid activity definition")
+(exp/defmsg ::act/extensions
+  "should be valid Activity extensions")
+(exp/defmsg ::act/extension
+  "should be a valid Activity extension")
 
 (exp/defmsg ::t/type-or-reference
   "should not contain both objectActivityType and objectStatementRefTemplate")
@@ -140,6 +144,8 @@
 
 ;; Context spec messages
 
+(exp/defmsg ::ctx/_context
+  "should be a valid IRI or inline context")
 (exp/defmsg ::ctx/expanded-key
   "should be a JSON-LD keyword or language tag")
 
@@ -321,7 +327,7 @@
            (ppr-str value)
            (pr-str (get-prop-from-path path))
            (ppr-str obj)))
-    ;; Error occured on Profile metadata
+    ;; Error occured on Profile metadata or some other nested object
     :else
     (let [obj (-> profile elide-arrs map->sorted-map)]
       (fmt (str "Value:\n"

--- a/src/main/com/yetanalytics/pan/objects/concept.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concept.cljc
@@ -48,6 +48,18 @@
    :recommendedActivityTypes
    :recommendedVerbs])
 
+(def external-iri-keys
+  [:broadMatch :narrowMatch :relatedMatch :exactMatch
+   :recommendedActivityTypes :recommendedVerbs
+   :context :schema])
+
+(defn get-external-iris
+  "Return the external IRIs from the Concepts of `profile`."
+  [profile]
+  (let [{:keys [concepts]} profile
+        id-filter-set      (set (ids/objs->ids concepts))]
+    (ids/objs->out-ids-map concepts external-iri-keys id-filter-set)))
+
 (defn- get-graph-concepts
   [profile extra-profiles]
   (let [concepts (:concepts profile)

--- a/src/main/com/yetanalytics/pan/objects/concepts/activities.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/activities.cljc
@@ -54,21 +54,14 @@
   (s/keys :req-un [::id ::type ::inScheme ::activityDefinition]
           :opt-un [::deprecated]))
 
+;; The following MUST is validated during context validation
+;; MUST ensure every extension `@context` is sufficient to guarantee all
+;; properties in the extension expand to absolute IRIs during JSON-LD
+;; processing.
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; in-profile validation+ helpers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Currently does nothing
 (defmethod graph/edges-with-attrs "Activity" [_] [])
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; advanced processing for spec MUSTS
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; TODO: spec MUSTs activity definition w/ extension
-;; - MUST include JSON-LD @context in all top-level objects of extensions
-;; - MUST ensure every extension @context is sufficient to guareantee all 
-;;   properties in the extension expand to absolute IRIs during JSON-LD 
-;;   processing
-;; - see Profile Authors: bellow table at:
-;; https://github.com/adlnet/xapi-profiles/blob/master/xapi-profiles-structure.md#74-activities

--- a/src/main/com/yetanalytics/pan/objects/concepts/extensions/activity.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/extensions/activity.cljc
@@ -50,9 +50,5 @@
 ;; validation which requires external calls
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; TODO: json-ld context validation
-;; context - valid json-ld context
-
 ;; TODO: get string from iri
-
 ;; schema - json-schema string at other end of iri

--- a/src/main/com/yetanalytics/pan/objects/concepts/extensions/context.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/extensions/context.cljc
@@ -49,7 +49,5 @@
 ;; validation which requires external calls
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; TODO: json-ld context validation
-;; context - valid json-ld context
 ;; TODO: get string from iri
 ;; schema - json-schema string at other end of iri

--- a/src/main/com/yetanalytics/pan/objects/concepts/extensions/result.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/extensions/result.cljc
@@ -49,10 +49,5 @@
 ;; validation which requires external calls
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; TODO: json-ld context validation
-
-;; context - valid json-ld context
-
 ;; TODO: get string from iri
-
 ;; schema - json-schema string at other end of iri

--- a/src/main/com/yetanalytics/pan/objects/pattern.cljc
+++ b/src/main/com/yetanalytics/pan/objects/pattern.cljc
@@ -88,6 +88,14 @@
 (def pattern-iri-keys
   [:sequence :alternates :optional :oneOrMore :zeroOrMore])
 
+(defn get-external-iris
+  "Return the external IRIs from the Patterns of `profile`."
+  [profile]
+  (let [{:keys [templates patterns]} profile
+        id-filter-set (set (concat (ids/objs->ids templates)
+                                   (ids/objs->ids patterns)))]
+    (ids/objs->out-ids-map patterns pattern-iri-keys id-filter-set)))
+
 ;; ;;;;; Node and Edge Creation ;;;;;
 
 ;; Get the IRIs of a Pattern (within a sequence), depending on its property

--- a/src/main/com/yetanalytics/pan/objects/template.cljc
+++ b/src/main/com/yetanalytics/pan/objects/template.cljc
@@ -102,6 +102,14 @@
    :objectStatementRefTemplate
    :contextStatementRefTemplate])
 
+(defn get-external-iris
+  "Return the external IRIs from the Statement Templates of `profile`."
+  [profile]
+  (let [{:keys [concepts templates]} profile
+        id-filter-set (set (concat (ids/objs->ids concepts)
+                                   (ids/objs->ids templates)))]
+    (ids/objs->out-ids-map templates template-iri-keys id-filter-set)))
+
 (defn get-graph-concept-templates
   [profile ?extra-profiles]
   (let [templates (:templates profile)

--- a/src/main/com/yetanalytics/pan/objects/templates/rules.cljc
+++ b/src/main/com/yetanalytics/pan/objects/templates/rules.cljc
@@ -25,17 +25,16 @@
 ;; NOTE: Need to separate out logic due to weird bug in Expound that causes
 ;; it to crash when `or` is used in s/keys.
 (s/def ::rule-keywords
-       (fn has-rule-keyword? [rule]
-         (or (contains? rule :presence)
-             (contains? rule :any)
-             (contains? rule :all)
-             (contains? rule :none))))
+  (fn has-rule-keyword? [rule]
+    (or (contains? rule :presence)
+        (contains? rule :any)
+        (contains? rule :all)
+        (contains? rule :none))))
 
 (s/def ::rule
-       (s/and ::rule-keys ::rule-keywords))
+  (s/and ::rule-keys ::rule-keywords))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; validation which requires external calls
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; TODO: rule-must:context 
+;; The following MUST is validated during context validation:
+;; A Profile Author MUST include the keys of any non-primitive objects in `any`,
+;; `all`, and `none` in additional `@context` beyond the ones provided by
+;; this specification.

--- a/src/test/com/yetanalytics/pan_test.cljc
+++ b/src/test/com/yetanalytics/pan_test.cljc
@@ -44,8 +44,7 @@
 (deftest error-tests
   (are [profile-name profile res]
        (testing (str "the " profile-name ", without printing")
-         (let [[correct-syntax? correct-ids? correct-graph? correct-ctxt?]
-               res
+         (let [[correct-syntax? correct-ids? correct-graph? correct-ctxt?] res
                syntax-errs (validate-profile profile
                                              :print-errs? false)
                id-errs     (validate-profile profile

--- a/src/test/com/yetanalytics/pan_test.cljc
+++ b/src/test/com/yetanalytics/pan_test.cljc
@@ -1,8 +1,8 @@
 (ns com.yetanalytics.pan-test
   (:require [clojure.test :refer [deftest testing is are]]
             [clojure.spec.alpha :as s]
-            [com.yetanalytics.pan :refer [validate-profile
-                                          validate-profile-coll]]
+            [com.yetanalytics.pan :as p :refer [validate-profile
+                                                validate-profile-coll]]
             [com.yetanalytics.pan.objects.profile :as profile]
             [com.yetanalytics.pan.errors :as e]
             [com.yetanalytics.pan-test-fixtures :as fix])
@@ -203,3 +203,27 @@
                                                 :syntax? true
                                                 :ids? true
                                                 :context? true))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; External IRI retrieval tests
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(deftest get-external-iri-test
+  (testing "get-external-iris function"
+    (is (= {:exactMatch
+            #{"https://w3id.org/xapi/profiles/ontology#Profile"
+              "https://w3id.org/xapi/cmi5/activities/course"
+              "http://activitystrea.ms/schema/terminate"
+              "http://activitystrea.ms/schema/complete"}
+            :context
+            #{"https://raw.githubusercontent.com/adlnet/xAPI-SCORM-Profile/master/context/attempt-state-context.jsonld"}
+            :schema
+            #{"https://raw.githubusercontent.com/adlnet/xAPI-SCORM-Profile/master/document-schemas/scorm.profile.agent.profile.schema.json"
+              "https://w3id.org/xapi/scorm/activity-profile/scorm.profile.activity.profile.schema"
+              "https://raw.githubusercontent.com/adlnet/xAPI-SCORM-Profile/master/document-schemas/scorm.profile.attempt.state.schema.json"
+              "https://raw.githubusercontent.com/adlnet/xAPI-SCORM-Profile/master/document-schemas/scorm.profile.activity.state.schema.json"}
+            :verb
+            #{"http://adlnet.gov/expapi/verbs/commented"}
+            :objectActivityType
+            #{"http://adlnet.gov/expapi/activities/cmi.interaction"}}
+           (p/get-external-iris scorm-profile-raw)))))

--- a/src/test/com/yetanalytics/pan_test/context_test.cljc
+++ b/src/test/com/yetanalytics/pan_test/context_test.cljc
@@ -121,6 +121,6 @@
         (is (some? err))
         (is (= #{:id :display :en-US}
                (->> err ::s/problems (map :val) set)))
-        (is (= #{`ax/non-empty-string? `c/jsonld-keyword? `c/lang-tag?}
+        (is (= #{`ax/non-empty-string? `c/lang-tag? #{"@id" "@type"}}
                (->> err ::s/problems (map :pred) set))))
       (is (some? (c/validate-contexts ex-profile))))))

--- a/src/test/com/yetanalytics/pan_test/context_test.cljc
+++ b/src/test/com/yetanalytics/pan_test/context_test.cljc
@@ -1,9 +1,7 @@
 (ns com.yetanalytics.pan-test.context-test
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.spec.alpha :as s]
-            [clojure.zip :as zip]
-            [com.yetanalytics.pan.context :as c]
-            [com.yetanalytics.test-utils :refer [should-satisfy+]])
+            [com.yetanalytics.pan.context :as c])
   #?(:clj (:require [com.yetanalytics.pan.utils.resources
                      :refer [read-json-resource]])
      :cljs (:require-macros [com.yetanalytics.pan.utils.resources
@@ -11,296 +9,107 @@
 
 (def profile-context
   (->> "https://w3id.org/xapi/profiles/context"
-       (get c/default-context-map)
-       :at/context))
+       (get c/default-context-map)))
 
 (def activity-context
   (->> "https://w3id.org/xapi/profiles/activity-context"
-       (get c/default-context-map)
-       :at/context))
+       (get c/default-context-map)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Parsing and validating context tests 
+;; Context spec tests
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; TODO Test getting external @context
-(deftest uri->context-test
-  (testing "uri->context function: Get @context and convert from JSON to EDN."
-    (is (map? profile-context))
-    (is (= {:xapi                    "https://w3id.org/xapi/ontology#"
-            :type                    {:at/id   "xapi:type"
-                                      :at/type "@id"}
-            :name                    {:at/id        "xapi:name"
-                                      :at/container "@language"}
-            :description             {:at/id        "xapi:description"
-                                      :at/container "@language"}
-            :moreInfo                {:at/id   "xapi:moreInfo"
-                                      :at/type "@id"}
-            :extensions              {:at/id        "xapi:extensions"
-                                      :at/container "@set"}
-            :interactionType         {:at/id "xapi:interactionType"}
-            :correctResponsesPattern {:at/id        "xapi:correctResponsesPattern"
-                                      :at/container "@set"}
-            :choices                 {:at/id        "xapi:choices"
-                                      :at/container "@list"}
-            :scale                   {:at/id        "xapi:scale"
-                                      :at/container "@list"}
-            :source                  {:at/id        "xapi:source"
-                                      :at/container "@list"}
-            :target                  {:at/id        "xapi:target"
-                                      :at/container "@list"}
-            :steps                   {:at/id        "xapi:steps"
-                                      :at/container "@list"}
-            :id                      {:at/id "xapi:interactionId"}}
-           activity-context))))
-
-(deftest prefix-spec-test
-  (testing "prefix spec"
-    (should-satisfy+ ::c/context-prefix
-                     "https://w3id.org/xapi/ontology#"
-                     "https://foo.org/"
-                     "https://foo.org?"
-                     :bad
-                     "Profile"
-                     "what the pineapple"
-                     "https//bad-uri/"
-                     "https://w3id.org/xapi/ontology")
-    (should-satisfy+ ::c/context-prefix
-                     {:id "http://example.com/compact-iris-" :prefix true}
-                     :bad
-                     {:id "http://example.com/compact-iris-" :prefix false}
-                     {:id "http://example.com/compact-iris-"})))
-
-(deftest collect-prefixes-test
-  (testing "collect-prefixes function: get all prefixes from a context"
-    (is (= {:prov "http://www.w3.org/ns/prov#"
-            :skos "http://www.w3.org/2004/02/skos/core#"
-            :xapi "https://w3id.org/xapi/ontology#"
-            :profile "https://w3id.org/xapi/profiles/ontology#"
-            :dcterms "http://purl.org/dc/terms/"
-            :schemaorg "http://schema.org/"
-            :rdfs "http://www.w3.org/2000/01/rdf-schema#"}
-           (c/collect-prefixes profile-context)))
-    (is (= {:xapi "https://w3id.org/xapi/ontology#"}
-           (c/collect-prefixes activity-context)))))
-
-(deftest compact-iri?-test
-  (testing "compact-iri? predicate"
-    (is (c/compact-iri? {:xapi "https://w3id.org/xapi/ontology#"}
-                        "xapi:Verb"))
-    (is (not (c/compact-iri? {:xapi "https://w3id.org/xapi/ontology#"}
-                             "skos:prefLabel")))
-    (is (not (c/compact-iri? {:xapi "https://w3id.org/xapi/ontology#"}
-                             {:at/id "xapi:type" :at/type "@id"})))))
-
-(deftest context-map?-test
-  (testing "context-map? predicate"
-    (is (c/context-map? {:xapi "https://w3id.org/xapi/ontology#"}
-                        {:at/id "xapi:type" :at/type "@id"}))
-    (is (not (c/context-map? {:xapi "https://w3id.org/xapi/ontology#"}
-                             {:at/type "@id" :at/id "dcterms:conformsTo"})))
-    (is (not (c/context-map? {:xapi "https://w3id.org/xapi/ontology#"}
-                             "xapi:Verb")))))
-
-(deftest validate-context-test
-  (testing "validate-context function"
-    (is (nil? (c/validate-context profile-context)))
-    (is (nil? (c/validate-context activity-context)))
-    (is (some? (c/validate-context
-                {:prefix "https://foo.org/prefix"
-                 :gamma {:at/id "prefix2:gamma"}})))
-    (is (some? (c/validate-context
-                {:xapi "https://w3id.org/xapi/ontology#"
-                 :Profile "profile:Profile"})))
-    (is (nil? (c/validate-context
-               {:xapi "https://w3id.org/xapi/ontology#"
-                :skos "http://www.w3.org/2004/02/skos/core#"
-                :prefLabel {:at/id "skos:prefLabel"
-                            :at/container "@language"}
-                :definition {:at/id "skos:definition"
-                             :at/container "@language"}})))
-    (is (= 10 (-> {:xapi "https://w3id.org/xapi/ontology#"
-                   :prefLabel {:at/id "skos:prefLabel"
-                               :at/container "@language"}
-                   :definition {:at/id "skos:definition"
-                                :at/container "@language"}}
-                  c/validate-context
-                  ::s/problems
-                  count)))))
+(deftest context-spec-test
+  (testing "::_context spec"
+    (s/valid? ::c/_context profile-context)
+    (s/valid? ::c/_context activity-context)
+    (s/valid? ::c/_context "https://w3id.org/xapi/profiles/context")
+    (s/valid? ::c/_context ["https://w3id.org/xapi/profiles/context"
+                            activity-context])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Validating profile against context tests
+;; Profile context tests
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def dummy-profile {:foo {:bar "b1" :baz "b2"}
-                    :nums [{:one 1} {:two 2} {:three 3}]
-                    :prefLabel {:en "example"}
-                    :_context "https://w3id.org/xapi/profiles/activity-context"})
+(def dummy-jsonld
+  {:foo       {:bar "b1"
+               :baz "b2"}
+   :nums      [{:one 1} {:two 2} {:three 3}]
+   :prefLabel {:en "example"}
+   :_context  "https://w3id.org/xapi/profiles/context"})
 
-(def ex-activity-def {:_context "https://w3id.org/xapi/profiles/activity-context"
-                      :name {:en "Example Activity Def"}
-                      :description {:en "This is an example"}
-                      :type "https://foo.org/bar"})
+(def ex-activity-def
+  {:_context    "https://w3id.org/xapi/profiles/activity-context"
+   :name        {:en "Example Activity Def"}
+   :description {:en "This is an example"}
+   :type        "https://foo.org/bar"})
 
-(deftest profile-to-zipper-test
-  (testing "profile-to-zipper function"
-    (is (= dummy-profile (zip/node (c/profile-to-zipper dummy-profile))))
-    (is (= '({:bar "b1" :baz "b2"} {:one 1} {:two 2} {:three 3})
-           (zip/children (c/profile-to-zipper dummy-profile))))
-    ;; Returns nil if there are no children
-    (is (= nil (zip/children (c/profile-to-zipper ex-activity-def)))))
-  (testing "dfs through a single profile"
-    (is (-> {:_context {:prefix "https://foo.org/prefix/"
-                        :alpha {:at/id "prefix:alpha"}
-                        :beta {:at/id "prefix:beta"}}
-             :alpha 116
-             :beta {:_context {:prefix2 "https://foo.org/prefix2"
-                               :gamma {:at/id "prefix2:gamma2"}}
-                    :alpha 9001
-                    :gamma "foo bar"}}
-            c/profile-to-zipper
-            zip/next
-            zip/next
-            zip/end?))))
+(def ex-context
+  {:ex "http://example.org/ontology/"
+   :id "@id"
+   :display {:_id "ex:display"
+             :_container "@language"}})
 
-(deftest pop-context-test
-  (testing "pop-context function"
-    ;; Do not pop if the context is located at a parent
-    (is (= [{:path [] :context activity-context :errors nil}]
-           (c/pop-context [{:path [] :context activity-context :errors nil}]
-                          (-> dummy-profile c/profile-to-zipper zip/down))))
-    ;; Do not pop if the context is located at the current node
-    (is (= [{:path [dummy-profile] :context activity-context :errors nil}]
-           (c/pop-context [{:path [dummy-profile] :context activity-context :errors nil}]
-                          (-> dummy-profile c/profile-to-zipper zip/down))))
-    ;; Pop if the current location is at a different branch
-    (is (= []
-           (c/pop-context [{:path [{:super "cali"}] :context activity-context :errors nil}]
-                          (-> dummy-profile c/profile-to-zipper))))
-    ;; Pop if the current location is a parent of the context location
-    (is (= []
-           (c/pop-context [{:path [dummy-profile {:super "cali"}]
-                            :context activity-context :errors nil}]
-                          (-> dummy-profile c/profile-to-zipper))))))
+(def ex-profile
+  {:id       "http://example.org"
+   :type     "Profile"
+   :_context "https://w3id.org/xapi/profiles/context"
+   :concepts [{:id                 "http://example.org/activity"
+               :type               "Activity"
+               :activityDefinition ex-activity-def}]
+   :templates [{:id    "http://example.org/template"
+                :type  "StatementTemplate"
+                :rules [{:location "$.verb"
+                         :any      [{:_context "http://example.org/context"
+                                     :id       "http://exampel.org/verb"
+                                     :display  {:en-US "Foo"}}]}]}]})
 
-(deftest pop-contexts-test
-  (testing "pop-contexts function"
-    (is (= [{:path [] :context activity-context :errors nil}]
-           (c/pop-contexts [{:path [] :context activity-context :errors nil}]
-                           (-> dummy-profile c/profile-to-zipper zip/down))))
-    (is (= [{:path [dummy-profile] :context activity-context :errors nil}]
-           (c/pop-contexts [{:path [dummy-profile] :context activity-context :errors nil}]
-                           (-> dummy-profile c/profile-to-zipper zip/down))))
-    (is (= []
-           (c/pop-contexts [{:path [{:super "cali"}] :context activity-context :errors nil}]
-                           (-> dummy-profile c/profile-to-zipper))))
-    (is (= [{:path [] :context activity-context :errors nil}]
-           (c/pop-contexts [{:path [] :context activity-context :errors nil}
-                            {:path [{:super "cali"}] :context activity-context :errors nil}]
-                           (-> dummy-profile c/profile-to-zipper))))
-    (is (= [{:path [] :context activity-context :errors nil}]
-           (c/pop-contexts [{:path [] :context activity-context :errors nil}
-                            {:path [dummy-profile] :context activity-context :errors nil}
-                            {:path [dummy-profile {:bar "b1" :baz "b2"}] :context activity-context :errors nil}]
-                           (-> dummy-profile c/profile-to-zipper))))))
+(def catch-profile
+  (read-json-resource "sample_profiles/catch.json" "_"))
 
-(deftest push-context-test
-  (testing "push-context function"
-    (is (= [{:path [] :context activity-context :errors nil}]
-           (c/push-context c/default-context-map
-                           []
-                           (-> dummy-profile c/profile-to-zipper))))
-    ;; Do not push if there is no @context key
-    (is (= [{:path [] :context activity-context :errors nil}]
-           (c/push-context c/default-context-map
-                           [{:path [] :context activity-context :errors nil}]
-                           (-> dummy-profile c/profile-to-zipper zip/down))))
-    ;; Push if we have a vector as an @context value
-    (is (= [{:path [] :context activity-context :errors nil}
-            {:path [] :context profile-context :errors nil}]
-           (c/push-context c/default-context-map
-                           []
-                           (c/profile-to-zipper
-                            {:foo      {:bar "b1"
-                                        :baz "b2"}
-                             :nums     [{:one 1} {:two 2} {:three 3}]
-                             :_context ["https://w3id.org/xapi/profiles/activity-context"
-                                        "https://w3id.org/xapi/profiles/context"]}))))))
-
-(deftest update-context-errors-test
-  (testing "update-context-errors function"
-    (is (= '({:a 1 :b 2}) (c/update-context-errors [] [] '({:a 1 :b 2}))))
-    (is (= '({:a 1 :b 2})
-           (c/update-context-errors [] [{:path [] :context nil :errors {:a 1 :b 2}}] '())))))
-
-(deftest search-contexts-test
-  (testing "search-contexts function"
-    (is (c/search-contexts [{:path [] :context activity-context :errors nil}] :type))
-    (is (c/search-contexts [{:path [] :context profile-context :errors nil}
-                            {:path [] :context activity-context :errors nil}] :versions))
-    (is (not (c/search-contexts [{:path [] :context activity-context :errors nil}] :context)))
-    (is (not (c/search-contexts [{:path [] :context activity-context :errors nil}] :foo)))))
-
-(deftest validate-keys-test
-  (testing "validate-keys spec"
-    (is (nil? (c/validate-keys [{:path [] :context profile-context :errors nil}]
-                               {:id "https://foo.org/" :type "Bar"})))
-    (is (nil? (c/validate-keys [{:path [] :context activity-context :errors nil}]
-                               {:id "https://foo.org/" :type "Bar"})))
-    (is (some? (c/validate-keys [{:path [] :context activity-context :errors nil}]
-                                {:prefLabel {:en "Blah"} :definition {:es "soy un dorito"}})))))
+(deftest expand-profile-keys-test
+  (testing "expand-profile-keys function"
+    (is (= {:foo       {:bar "b1"
+                        :baz "b2"}
+            :nums      [{:one 1} {:two 2} {:three 3}]
+            "http://www.w3.org/2004/02/skos/core#prefLabel"
+            {:_LANGTAG_en "example"}}
+           (c/expand-profile-keys dummy-jsonld)))
+    (is (= {"https://w3id.org/xapi/ontology#name"
+            {:_LANGTAG_en "Example Activity Def"}
+            "https://w3id.org/xapi/ontology#description"
+            {:_LANGTAG_en "This is an example"}
+            "https://w3id.org/xapi/ontology#type"
+            "https://foo.org/bar"}
+           (c/expand-profile-keys ex-activity-def)))
+    (is (= {"@id"   "http://example.org"
+            "@type" "Profile"
+            "https://w3id.org/xapi/profiles/ontology#concepts"
+            [{"@id" "http://example.org/activity"
+              "@type" "Activity"
+              "https://w3id.org/xapi/profiles/ontology#activityDefinition"
+              {"https://w3id.org/xapi/ontology#name"
+               {:_LANGTAG_en "Example Activity Def"}
+               "https://w3id.org/xapi/ontology#description"
+               {:_LANGTAG_en "This is an example"}
+               "https://w3id.org/xapi/ontology#type"
+               "https://foo.org/bar"}}]
+            "https://w3id.org/xapi/profiles/ontology#templates"
+            [{"@id"   "http://example.org/template"
+              "@type" "StatementTemplate"
+              "https://w3id.org/xapi/profiles/ontology#rules"
+              [{"https://w3id.org/xapi/profiles/ontology#location"
+                "$.verb"
+                "https://w3id.org/xapi/profiles/ontology#any"
+                [{"@id" "http://exampel.org/verb"
+                  "http://example.org/ontology/display"
+                  {:_LANGTAG_en-US "Foo"}}]}]}]}
+           (c/expand-profile-keys ex-profile
+                                  {"http://example.org/context" ex-context})))
+    (is (map? (c/expand-profile-keys catch-profile)))))
 
 (deftest validate-contexts-test
   (testing "validate-contexts function"
-    (is (= {:context-errors nil :context-key-errors nil}
-           (c/validate-contexts ex-activity-def)))
-    (is (not= {:context-errors nil :context-key-errors nil}
-              (c/validate-contexts dummy-profile)))
-    (is (= {:context-errors nil :context-key-errors nil}
-           (c/validate-contexts
-            {:_context {:prefix "https://foo.org/prefix/"
-                        :alpha {:at/id "prefix:alpha"}
-                        :beta {:at/id "prefix:beta"}}
-             :alpha 116
-             :beta {:_context {:prefix2 "https://foo.org/prefix2/"
-                               :gamma {:at/id "prefix2:gamma2"}}
-                    :alpha 9001
-                    :gamma "foo bar"}})))
-    (is (some? (:context-errors (c/validate-contexts
-                                 {:_context {:prefix "https://foo.org/prefix/"
-                                             :gamma {:at/id "prefix2:gamma"}}
-                                  :gamma "foo bar"}))))
-    (is (nil? (:context-key-errors (c/validate-contexts
-                                    {:_context {:prefix "https://foo.org/prefix/"
-                                                :gamma {:at/id "prefix2:gamma"}}
-                                     :gamma "foo bar"}))))
-    (is (nil? (:context-errors (c/validate-contexts
-                                {:_context {:prefix2 "https://foo.org/prefix2/"
-                                            :gamma {:at/id "prefix2:gamma"}}
-                                 :alpha 9001}))))
-    (is (some? (:context-key-errors (c/validate-contexts
-                                     {:_context {:prefix2 "https://foo.org/prefix2/"
-                                                 :gamma {:at/id "prefix2:gamma"}}
-                                      :alpha 9001}))))
-    (is (= {:context-errors nil :context-key-errors nil}
-           (c/validate-contexts
-            {:_context "https://w3id.org/xapi/profiles/context"
-             :id "https://foo.org/profile"
-             :type "Profile"
-             :concepts [{:id "https://foo.org/activity"
-                         :type "Activity"
-                         :activityDefinition
-                         {:_context "https://w3id.org/xapi/profiles/activity-context"
-                          :name {:en "Name"}
-                          :description {:en "Description"}
-                          :extensions {:_context {:prefix "https://foo.org/prefix/"
-                                                  :alpha "prefix:alpha"}
-                                       :alpha 9001}}}]})))))
-
-(def catch-profile
-  (read-json-resource "sample_profiles/catch.json" ""))
-
-(deftest validate-contexts-integration-test
-  (testing "integration testing on Will's CATCH profile"
-    (is (= {:context-errors nil :context-key-errors nil}
-           (c/validate-contexts catch-profile)))))
+    (is (nil? (c/validate-contexts ex-profile
+                                   {"http://example.org/context" ex-context})))
+    (is (nil? (c/validate-contexts catch-profile)))))

--- a/src/test/com/yetanalytics/pan_test/context_test.cljc
+++ b/src/test/com/yetanalytics/pan_test/context_test.cljc
@@ -10,10 +10,14 @@
                              :refer [read-json-resource]])))
 
 (def profile-context
-  (c/uri->context "https://w3id.org/xapi/profiles/context"))
+  (->> "https://w3id.org/xapi/profiles/context"
+       (get c/default-context-map)
+       :at/context))
 
 (def activity-context
-  (c/uri->context "https://w3id.org/xapi/profiles/activity-context"))
+  (->> "https://w3id.org/xapi/profiles/activity-context"
+       (get c/default-context-map)
+       :at/context))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Parsing and validating context tests 
@@ -23,21 +27,31 @@
 (deftest uri->context-test
   (testing "uri->context function: Get @context and convert from JSON to EDN."
     (is (map? profile-context))
-    (is (= {:xapi "https://w3id.org/xapi/ontology#"
-            :type {:at/id "xapi:type" :at/type "@id"}
-            :name {:at/id "xapi:name" :at/container "@language"}
-            :description {:at/id "xapi:description" :at/container "@language"}
-            :moreInfo {:at/id "xapi:moreInfo" :at/type "@id"}
-            :extensions {:at/id "xapi:extensions" :at/container "@set"}
-            :interactionType {:at/id "xapi:interactionType"}
-            :correctResponsesPattern {:at/id "xapi:correctResponsesPattern"
+    (is (= {:xapi                    "https://w3id.org/xapi/ontology#"
+            :type                    {:at/id   "xapi:type"
+                                      :at/type "@id"}
+            :name                    {:at/id        "xapi:name"
+                                      :at/container "@language"}
+            :description             {:at/id        "xapi:description"
+                                      :at/container "@language"}
+            :moreInfo                {:at/id   "xapi:moreInfo"
+                                      :at/type "@id"}
+            :extensions              {:at/id        "xapi:extensions"
                                       :at/container "@set"}
-            :choices {:at/id "xapi:choices" :at/container "@list"}
-            :scale {:at/id "xapi:scale" :at/container "@list"}
-            :source {:at/id "xapi:source" :at/container "@list"}
-            :target {:at/id "xapi:target" :at/container "@list"}
-            :steps {:at/id "xapi:steps" :at/container "@list"}
-            :id {:at/id "xapi:interactionId"}}
+            :interactionType         {:at/id "xapi:interactionType"}
+            :correctResponsesPattern {:at/id        "xapi:correctResponsesPattern"
+                                      :at/container "@set"}
+            :choices                 {:at/id        "xapi:choices"
+                                      :at/container "@list"}
+            :scale                   {:at/id        "xapi:scale"
+                                      :at/container "@list"}
+            :source                  {:at/id        "xapi:source"
+                                      :at/container "@list"}
+            :target                  {:at/id        "xapi:target"
+                                      :at/container "@list"}
+            :steps                   {:at/id        "xapi:steps"
+                                      :at/container "@list"}
+            :id                      {:at/id "xapi:interactionId"}}
            activity-context))))
 
 (deftest prefix-spec-test
@@ -193,20 +207,25 @@
 (deftest push-context-test
   (testing "push-context function"
     (is (= [{:path [] :context activity-context :errors nil}]
-           (c/push-context [] (-> dummy-profile c/profile-to-zipper))))
+           (c/push-context c/default-context-map
+                           []
+                           (-> dummy-profile c/profile-to-zipper))))
     ;; Do not push if there is no @context key
     (is (= [{:path [] :context activity-context :errors nil}]
-           (c/push-context [{:path [] :context activity-context :errors nil}]
+           (c/push-context c/default-context-map
+                           [{:path [] :context activity-context :errors nil}]
                            (-> dummy-profile c/profile-to-zipper zip/down))))
     ;; Push if we have a vector as an @context value
     (is (= [{:path [] :context activity-context :errors nil}
             {:path [] :context profile-context :errors nil}]
-           (c/push-context
-            [] (c/profile-to-zipper
-                {:foo {:bar "b1" :baz "b2"}
-                 :nums [{:one 1} {:two 2} {:three 3}]
-                 :_context ["https://w3id.org/xapi/profiles/activity-context"
-                            "https://w3id.org/xapi/profiles/context"]}))))))
+           (c/push-context c/default-context-map
+                           []
+                           (c/profile-to-zipper
+                            {:foo      {:bar "b1"
+                                        :baz "b2"}
+                             :nums     [{:one 1} {:two 2} {:three 3}]
+                             :_context ["https://w3id.org/xapi/profiles/activity-context"
+                                        "https://w3id.org/xapi/profiles/context"]}))))))
 
 (deftest update-context-errors-test
   (testing "update-context-errors function"

--- a/src/test/com/yetanalytics/pan_test/context_test.cljc
+++ b/src/test/com/yetanalytics/pan_test/context_test.cljc
@@ -29,6 +29,19 @@
                             activity-context])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Context IRI retrieval tests
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(deftest get-context-iris-test
+  (testing "get-context-iris function"
+    (is (= ["http://foo.org" "http://bar.org"]
+           (c/get-context-iris
+            {:_context "http://foo.org"
+             :children [{:_context ["http://bar.org"
+                                    "https://w3id.org/xapi/profiles/context"
+                                    {}]}]})))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Profile context tests
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/test/com/yetanalytics/pan_test/errors_test.cljc
+++ b/src/test/com/yetanalytics/pan_test/errors_test.cljc
@@ -207,8 +207,8 @@
       fix/err-msg-9 {:pattern-edge-errors
                      (pt/validate-pattern-edges
                       (pt/create-graph bad-profile-2h))}
-      fix/err-msg-10 (ctx/validate-contexts bad-profile-3a)
-      fix/err-msg-11 (ctx/validate-contexts bad-profile-3b)))
+      fix/err-msg-10 {:context-errors
+                      (ctx/validate-contexts bad-profile-3b)}))
   (testing "combining error messages"
     (is (= (str fix/err-msg-4 fix/err-msg-5)
            (-> {:id-errors (id/validate-ids bad-profile-2c)

--- a/src/test/com/yetanalytics/pan_test/errors_test.cljc
+++ b/src/test/com/yetanalytics/pan_test/errors_test.cljc
@@ -147,26 +147,22 @@
 
 ;; This profile has two invalid contexts
 (def bad-profile-3a
-  {:id       "https://foo.org/profile"
-   :type     "Profile"
-   :_context {:type                "@type"
-              :id                  "@id"
-              :prov                "http://www.w3.org/ns/prov#"
-              :skos                "http://www.w3.org/2004/02/skos/core#"
-              :profile             "https://w3id.org/xapi/profiles/ontology#"
-              :Profile             "profile:Profile"
-              :Verb                "xapi:Verb"
-              :ActivityType        "xapi:ActivityType"
-              :AttachmentUsageType "xapi:AttachmentUsageType"}
-   :concepts [{:id       "https://foo.org/activity/1"
-               :type     "Activity"
-               :_context {:type    "@type"
-                          :id      "@id"
-                          :prov    "http://www.w3.org/ns/prov#"
-                          :skos    "http://www.w3.org/2004/02/skos/core#"
-                          :Profile "profile:Profile"}}]})
+  (assoc good-profile-1
+         :concepts
+         [{:id       "https://foo.org/activity/1"
+           :type     "Activity"
+           :inScheme "https://w3id.org/xapi/catch/v1"
+           :activityDefinition
+           {:_context "https://w3id.org/xapi/profiles/activity-context"
+            :extensions
+            {"http://foo.org"
+             {:_context {:type    "@type"
+                         :id      "@id"
+                         :prov    "http://www.w3.org/ns/prov#"
+                         :skos    "http://www.w3.org/2004/02/skos/core#"
+                         :Profile {:id "bee"}}}}}}]))
 
-;; This profile has two instances where keys cannot be expanded via @context
+;; This profile has three instances where keys cannot be expanded via @context
 (def bad-profile-3b
   {:id       "https://foo.org/profile"
    :type     "Profile"
@@ -175,8 +171,11 @@
    :baz      "Qux"
    :concepts [{:id       "https://foo.org/activity/1"
                :type     "Activity"
-               :_context "https://w3id.org/xapi/profiles/activity-context"
-               :hello    "World"}]})
+               :activityDefinition
+               {:_context "https://w3id.org/xapi/profiles/activity-context"
+                :id       "https://foo.org/activity-name-1"
+                :type     "https://foo.org/activity-type-1"
+                :hello    "World"}}]})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Tests
@@ -207,7 +206,9 @@
       fix/err-msg-9 {:pattern-edge-errors
                      (pt/validate-pattern-edges
                       (pt/create-graph bad-profile-2h))}
-      fix/err-msg-10 {:context-errors
+      fix/err-msg-10 {:syntax-errors
+                      (p/validate bad-profile-3a)}
+      fix/err-msg-11 {:context-errors
                       (ctx/validate-contexts bad-profile-3b)}))
   (testing "combining error messages"
     (is (= (str fix/err-msg-4 fix/err-msg-5)

--- a/src/test/com/yetanalytics/pan_test/errors_test_fixtures.cljc
+++ b/src/test/com/yetanalytics/pan_test/errors_test_fixtures.cljc
@@ -446,7 +446,7 @@ should not refer to itself
 Detected 1 error
 ")
 
-;; Context errors
+;; Context key errors
 
 (def err-msg-10
   "
@@ -454,184 +454,56 @@ Detected 1 error
 
 -- Spec failed --------------------
 
-Value:
-\"profile:Profile\"
-
-in context:
-{:id \"@id\",
- :type \"@type\",
- :Profile \"profile:Profile\",
- :prov \"http://www.w3.org/ns/prov#\",
- :skos \"http://www.w3.org/2004/02/skos/core#\"}
-
-should be a JSON-LD context keyword
-
-or
-
-should be a JSON-LD prefix
-
-or
-
-should be a simple term definition with a valid prefix
-
-or
-
-should be an expanded term definition with a valid prefix
-
--- Spec failed --------------------
-
-Value:
-\"xapi:Verb\"
-
-in context:
-{:id \"@id\",
- :type \"@type\",
- :ActivityType \"xapi:ActivityType\",
- :AttachmentUsageType \"xapi:AttachmentUsageType\",
- :Profile \"profile:Profile\",
- :Verb \"xapi:Verb\",
- :profile \"https://w3id.org/xapi/profiles/ontology#\",
- :prov \"http://www.w3.org/ns/prov#\",
- :skos \"http://www.w3.org/2004/02/skos/core#\"}
-
-should be a JSON-LD context keyword
-
-or
-
-should be a JSON-LD prefix
-
-or
-
-should be a simple term definition with a valid prefix
-
-or
-
-should be an expanded term definition with a valid prefix
-
--- Spec failed --------------------
-
-Value:
-\"xapi:ActivityType\"
-
-in context:
-{:id \"@id\",
- :type \"@type\",
- :ActivityType \"xapi:ActivityType\",
- :AttachmentUsageType \"xapi:AttachmentUsageType\",
- :Profile \"profile:Profile\",
- :Verb \"xapi:Verb\",
- :profile \"https://w3id.org/xapi/profiles/ontology#\",
- :prov \"http://www.w3.org/ns/prov#\",
- :skos \"http://www.w3.org/2004/02/skos/core#\"}
-
-should be a JSON-LD context keyword
-
-or
-
-should be a JSON-LD prefix
-
-or
-
-should be a simple term definition with a valid prefix
-
-or
-
-should be an expanded term definition with a valid prefix
-
--- Spec failed --------------------
-
-Value:
-\"xapi:AttachmentUsageType\"
-
-in context:
-{:id \"@id\",
- :type \"@type\",
- :ActivityType \"xapi:ActivityType\",
- :AttachmentUsageType \"xapi:AttachmentUsageType\",
- :Profile \"profile:Profile\",
- :Verb \"xapi:Verb\",
- :profile \"https://w3id.org/xapi/profiles/ontology#\",
- :prov \"http://www.w3.org/ns/prov#\",
- :skos \"http://www.w3.org/2004/02/skos/core#\"}
-
-should be a JSON-LD context keyword
-
-or
-
-should be a JSON-LD prefix
-
-or
-
-should be a simple term definition with a valid prefix
-
-or
-
-should be an expanded term definition with a valid prefix
-
--------------------------
-Detected 4 errors
-")
-
-;; Context key errors
-
-(def err-msg-11
-  "
-**** Context Key Errors ****
-
--- Spec failed --------------------
-
-Value:
-:hello
-
-in object:
-{:id \"https://foo.org/activity/1\",
- :type \"Activity\",
- :_context \"https://w3id.org/xapi/profiles/activity-context\",
- :hello \"World\"}
-
-should be expandable into an absolute IRI
-
-or
-
-should be a JSON-LD keyword
-
--- Spec failed --------------------
-
-Value:
+Key:
 :foo
 
 in object:
-{:id \"https://foo.org/profile\",
- :type \"Profile\",
- :_context \"https://w3id.org/xapi/profiles/context\",
- :concepts [...],
+{\"@id\" \"https://foo.org/profile\",
+ \"@type\" \"Profile\",
  :baz \"Qux\",
- :foo \"Bar\"}
+ :foo \"Bar\",
+ \"https://w3id.org/xapi/profiles/ontology#concepts\" [...]}
 
-should be expandable into an absolute IRI
+should be a non-empty string
 
 or
 
-should be a JSON-LD keyword
+should be a JSON-LD keyword or language tag
 
 -- Spec failed --------------------
 
-Value:
+Key:
 :baz
 
 in object:
-{:id \"https://foo.org/profile\",
- :type \"Profile\",
- :_context \"https://w3id.org/xapi/profiles/context\",
- :concepts [...],
+{\"@id\" \"https://foo.org/profile\",
+ \"@type\" \"Profile\",
  :baz \"Qux\",
- :foo \"Bar\"}
+ :foo \"Bar\",
+ \"https://w3id.org/xapi/profiles/ontology#concepts\" [...]}
 
-should be expandable into an absolute IRI
+should be a non-empty string
 
 or
 
-should be a JSON-LD keyword
+should be a JSON-LD keyword or language tag
+
+-- Spec failed --------------------
+
+Key:
+:hello
+
+in object:
+{:hello \"World\",
+ \"https://w3id.org/xapi/ontology#interactionId\"
+ \"https://foo.org/activity/1\",
+ \"https://w3id.org/xapi/ontology#type\" \"Activity\"}
+
+should be a non-empty string
+
+or
+
+should be a JSON-LD keyword or language tag
 
 -------------------------
 Detected 3 errors

--- a/src/test/com/yetanalytics/pan_test/errors_test_fixtures.cljc
+++ b/src/test/com/yetanalytics/pan_test/errors_test_fixtures.cljc
@@ -582,7 +582,11 @@ should be a non-empty string
 
 or
 
-should be a JSON-LD keyword or language tag
+should be a language tag
+
+or
+
+should be one of: \"@id\", \"@type\"
 
 -- Spec failed --------------------
 
@@ -600,7 +604,11 @@ should be a non-empty string
 
 or
 
-should be a JSON-LD keyword or language tag
+should be a language tag
+
+or
+
+should be one of: \"@id\", \"@type\"
 
 -- Spec failed --------------------
 
@@ -618,7 +626,11 @@ should be a non-empty string
 
 or
 
-should be a JSON-LD keyword or language tag
+should be a language tag
+
+or
+
+should be one of: \"@id\", \"@type\"
 
 -------------------------
 Detected 3 errors

--- a/src/test/com/yetanalytics/pan_test/errors_test_fixtures.cljc
+++ b/src/test/com/yetanalytics/pan_test/errors_test_fixtures.cljc
@@ -446,9 +446,123 @@ should not refer to itself
 Detected 1 error
 ")
 
-;; Context key errors
+;; Context errors
 
 (def err-msg-10
+  "
+**** Syntax Errors ****
+
+-- Spec failed --------------------
+
+Value:
+{:type \"@type\",
+ :id \"@id\",
+ :prov \"http://www.w3.org/ns/prov#\",
+ :skos \"http://www.w3.org/2004/02/skos/core#\",
+ :Profile {:id \"bee\"}}
+
+of property:
+:_context
+
+in object:
+{:id \"https://foo.org/activity/1\",
+ :type \"Activity\",
+ :inScheme \"https://w3id.org/xapi/catch/v1\",
+ :activityDefinition
+ {:_context \"https://w3id.org/xapi/profiles/activity-context\",
+  :extensions
+  {\"http://foo.org\"
+   {:_context
+    {:type \"@type\",
+     :id \"@id\",
+     :prov \"http://www.w3.org/ns/prov#\",
+     :skos \"http://www.w3.org/2004/02/skos/core#\",
+     :Profile {:id \"bee\"}}}}}}
+
+should be a non-empty string
+
+or
+
+should be a valid inline context
+
+-- Spec failed --------------------
+
+Value:
+{:id \"bee\"}
+
+of property:
+:Profile
+
+in object:
+{:id \"https://foo.org/activity/1\",
+ :type \"Activity\",
+ :inScheme \"https://w3id.org/xapi/catch/v1\",
+ :activityDefinition
+ {:_context \"https://w3id.org/xapi/profiles/activity-context\",
+  :extensions
+  {\"http://foo.org\"
+   {:_context
+    {:type \"@type\",
+     :id \"@id\",
+     :prov \"http://www.w3.org/ns/prov#\",
+     :skos \"http://www.w3.org/2004/02/skos/core#\",
+     :Profile {:id \"bee\"}}}}}}
+
+should be one of: \"@id\", \"@type\"
+
+or
+
+should satisfy
+
+  string?
+
+or
+
+should be a non-empty string
+
+or
+
+should contain key: :_id
+
+| key  | spec                                              |
+|======+===================================================|
+| :_id | <can't find spec for unqualified spec identifier> |
+
+-- Spec failed --------------------
+
+Value:
+{:_context
+ {:type \"@type\",
+  :id \"@id\",
+  :prov \"http://www.w3.org/ns/prov#\",
+  :skos \"http://www.w3.org/2004/02/skos/core#\",
+  :Profile {:id \"bee\"}}}
+
+of property:
+:extensions
+
+in object:
+{:id \"https://foo.org/activity/1\",
+ :type \"Activity\",
+ :inScheme \"https://w3id.org/xapi/catch/v1\",
+ :activityDefinition
+ {:_context \"https://w3id.org/xapi/profiles/activity-context\",
+  :extensions
+  {\"http://foo.org\"
+   {:_context
+    {:type \"@type\",
+     :id \"@id\",
+     :prov \"http://www.w3.org/ns/prov#\",
+     :skos \"http://www.w3.org/2004/02/skos/core#\",
+     :Profile {:id \"bee\"}}}}}}
+
+should be a valid Activity extension
+
+-------------------------
+Detected 3 errors
+")
+
+(def err-msg-11
   "
 **** Context Errors ****
 
@@ -496,8 +610,9 @@ Key:
 in object:
 {:hello \"World\",
  \"https://w3id.org/xapi/ontology#interactionId\"
- \"https://foo.org/activity/1\",
- \"https://w3id.org/xapi/ontology#type\" \"Activity\"}
+ \"https://foo.org/activity-name-1\",
+ \"https://w3id.org/xapi/ontology#type\"
+ \"https://foo.org/activity-type-1\"}
 
 should be a non-empty string
 

--- a/src/test/com/yetanalytics/pan_test/objects_test/concepts_test/activity_test.cljc
+++ b/src/test/com/yetanalytics/pan_test/objects_test/concepts_test/activity_test.cljc
@@ -30,7 +30,7 @@
             :name {"en" "Blah"}
             :description {"en" "Blah Blah Blah"}
             :type "https://w3id.org/xapi/catch/activitytypes/blah"}
-           (activities/stringify-lang-keys
+           (activities/stringify-submaps
             {:_context "https://w3id.org/xapi/profiles/activity-context"
              :name {:en "Blah"}
              :description {:en "Blah Blah Blah"}
@@ -42,7 +42,27 @@
                   {:_context "https://w3id.org/xapi/profiles/activity-context"
                    :name {:en "Cross Linguistic Connections"}
                    :description {"en" "The cross linguistic connections competency as described by the EPISD Dual Language Competency Framework"}
-                   :type "https://w3id.org/xapi/catch/activitytypes/competency"}))))
+                   :type "https://w3id.org/xapi/catch/activitytypes/competency"}))
+    (testing "with extension object"
+      (is (s/valid? ::activities/activityDefinition
+                    {:_context "https://w3id.org/xapi/profiles/activity-context"
+                     :name {:en "Cross Linguistic Connections"}
+                     :description {"en" "The cross linguistic connections competency as described by the EPISD Dual Language Competency Framework"}
+                     :type "https://w3id.org/xapi/catch/activitytypes/competency"
+                     :extensions {"http://foo.org/extension-1"
+                                  {:_context {:foo "http://foo.org/"
+                                              :display {:_id        "foo:display"
+                                                        :_container "@language"}}
+                                   :display {:en-US "My Extension"}}
+                                  "http://foo.org/extension-2" 2}}))
+      (is (not (s/valid? ::activities/activityDefinition
+                         {:_context "https://w3id.org/xapi/profiles/activity-context"
+                          :name {:en "Cross Linguistic Connections"}
+                          :description {"en" "The cross linguistic connections competency as described by the EPISD Dual Language Competency Framework"}
+                          :type "https://w3id.org/xapi/catch/activitytypes/competency"
+                          :extensions {"http://foo.org/extension-1"
+                                       {:display {:en-US "My Extension"}}
+                                       "http://foo.org/extension-2" 2}}))))))
 
 (deftest activity-test
   (testing "Activity concept"


### PR DESCRIPTION
- Allow for passing in external contexts via the `:extra-contexts` arg
- Remove old context and context key validation, specs, and spec messages
- New context validation occurs during syntax validation
- New context key validation first expands the keys of the Profile, then validates said keys as IRIs
- Add `get-external-iris` helper function to the API, to allow users to more easily retrieve external Profiles and contexts