### PR TITLE
Add `:concept-rels?`, `:template-rels?`, and `:pattern-rels?` kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## 0.4.2 - 2022-03-03
+- Add `:concept-rels?`, `:template-rels?`, and `:pattern-rels?`, keyword arguments.
+
 ## 0.4.1 - 2022-02-25
 - Add `json-profile->edn` API function.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Arguments may be supplied for different levels of validation strictness, which a
     - the `recommendedVerbs` property for Context and Result Extensions
     - Determining Properties, `objectStatementRefTemplate` property and the `contextStatementRefTemplate` properties for Statement Templates.
     - `sequence`, `alternates`, `optional`, `oneOrMore` and `zeroOrMore` properties for Patterns.
+- `:concept-rels?`, `:template-rels?`, `:pattern-rels?` - Similar to `:relations?`, except that each only validates relations specific to Concept, Statement Template, and Pattern properties, respectively. Each are default `false`, and are overridden when `:relations?` are `true`.
 - `:contexts?` - Validate that all instances of `@context` resolve to valid JSON-LD contexts and that they allow all properties to expand out to absolute IRIs during JSON-LD processing. The `@context` property is always found in the Profile metadata and in Activity Definitions, though they can also be found in Extensions for said Activity Definitions.
 
 Other keyword arguments include:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Clojure library for validating xAPI Profiles, according to the [xAPI Profile s
 Add the following to the `:deps` map in your `deps.edn` file:
 
 ```clojure
-com.yetanalytics/project-pan {:mvn/version "0.4.1"
+com.yetanalytics/project-pan {:mvn/version "0.4.2"
                               :exclusions [org.clojure/clojure
                                            org.clojure/clojurescript]}
 ```

--- a/src/main/com/yetanalytics/pan/errors.cljc
+++ b/src/main/com/yetanalytics/pan/errors.cljc
@@ -523,7 +523,8 @@
          (cstr/join " "))))
 
 (defn errors->type-path-str-m
-  "Return a map of the form {:error-type {:path err-str}}"
+  "Given a map `{:err-type spec-err}`, return a map of the form
+   `{:err-type {:spec-path err-str}}`"
   [spec-errs-map]
   (reduce-kv (fn [m k v]
                (if (some? v)
@@ -537,7 +538,8 @@
              spec-errs-map))
 
 (defn errors->type-str-m
-  "Return a map of the form `{:error-type err-str}"
+  "Given a map `{:err-type spec-err}`, return a map of the form
+   `{:err-type err-str}`."
   [spec-errs-map]
   (reduce-kv (fn [m k v]
                (cond-> m
@@ -547,14 +549,14 @@
              spec-errs-map))
 
 (defn errors->string
-  "Return an error string."
-  [errors-map]
+  "Given a map `{:err-type spec-err}`, return an error string."
+  [spec-errors-map]
   (reduce-kv (fn [s k v]
                (cond-> s
                  (some? v)
                  (str "\n**** " (kw->header k) " ****\n\n" (error->str v k))))
              ""
-             errors-map))
+             spec-errors-map))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Expounding entire error map

--- a/src/test/com/yetanalytics/pan_test.cljc
+++ b/src/test/com/yetanalytics/pan_test.cljc
@@ -92,57 +92,6 @@
     "CATCH (fixed)" will-profile-fix [true true true true]
     "cmi5 (fixed)" cmi-profile-fix [true true false true]))
 
-(deftest relation-error-tests
-  (testing "Different relation keyword args"
-    (is (= #{:concept-edge-errors
-             :template-edge-errors
-             :pattern-edge-errors
-             :pattern-cycle-errors}
-           (->> (p/validate-profile will-profile-raw
-                                    :syntax?        false
-                                    :relations?     true
-                                    :concept-rels?  false
-                                    :template-rels? false
-                                    :pattern-rels?  false)
-                keys
-                set)
-           (->> (p/validate-profile will-profile-raw
-                                    :syntax?        false
-                                    :relations?     true
-                                    :concept-rels?  true
-                                    :template-rels? true
-                                    :pattern-rels?  true)
-                keys
-                set)))
-    (is (= #{:concept-edge-errors}
-           (->> (p/validate-profile will-profile-raw
-                                    :syntax?        false
-                                    :relations?     false
-                                    :concept-rels?  true
-                                    :template-rels? false
-                                    :pattern-rels?  false)
-                keys
-                set)))
-    (is (= #{:template-edge-errors}
-           (->> (p/validate-profile will-profile-raw
-                                    :syntax?        false
-                                    :relations?     false
-                                    :concept-rels?  false
-                                    :template-rels? true
-                                    :pattern-rels?  false)
-                keys
-                set)))
-    (is (= #{:pattern-edge-errors
-             :pattern-cycle-errors}
-           (->> (p/validate-profile will-profile-raw
-                                    :syntax?        false
-                                    :relations?     false
-                                    :concept-rels?  false
-                                    :template-rels? false
-                                    :pattern-rels?  true)
-                keys
-                set)))))
-
 (deftest catch-err-data-test
   (testing "the CATCH profile error data"
     (is (= 24 (-> (p/validate-profile will-profile-raw)
@@ -167,6 +116,93 @@
            (-> (p/validate-profile cmi-profile-raw)
                :syntax-errors
                ::s/spec)))))
+
+(deftest relation-error-tests
+  (testing "Different relation keyword args"
+    (is (= #{:concept-edge-errors
+             :template-edge-errors
+             :pattern-edge-errors
+             :pattern-cycle-errors}
+           (->> (p/validate-profile will-profile-raw
+                                    :syntax?        false
+                                    :relations?     true
+                                    :concept-rels?  false
+                                    :template-rels? false
+                                    :pattern-rels?  false)
+                keys
+                set)
+           (->> (p/validate-profile will-profile-raw
+                                    :syntax?        false
+                                    :relations?     true
+                                    :concept-rels?  true
+                                    :template-rels? true
+                                    :pattern-rels?  true)
+                keys
+                set)
+           (->> (p/validate-profile-coll [will-profile-raw]
+                                         :syntax?        false
+                                         :relations?     true
+                                         :concept-rels?  true
+                                         :template-rels? true
+                                         :pattern-rels?  true)
+                first
+                keys
+                set)))
+    (is (= #{:concept-edge-errors}
+           (->> (p/validate-profile will-profile-raw
+                                    :syntax?        false
+                                    :relations?     false
+                                    :concept-rels?  true
+                                    :template-rels? false
+                                    :pattern-rels?  false)
+                keys
+                set)
+           (->> (p/validate-profile-coll [will-profile-raw]
+                                         :syntax?        false
+                                         :relations?     false
+                                         :concept-rels?  true
+                                         :template-rels? false
+                                         :pattern-rels?  false)
+                first
+                keys
+                set)))
+    (is (= #{:template-edge-errors}
+           (->> (p/validate-profile will-profile-raw
+                                    :syntax?        false
+                                    :relations?     false
+                                    :concept-rels?  false
+                                    :template-rels? true
+                                    :pattern-rels?  false)
+                keys
+                set)
+           (->> (p/validate-profile-coll [will-profile-raw]
+                                         :syntax?        false
+                                         :relations?     false
+                                         :concept-rels?  false
+                                         :template-rels? true
+                                         :pattern-rels?  false)
+                first
+                keys
+                set)))
+    (is (= #{:pattern-edge-errors
+             :pattern-cycle-errors}
+           (->> (p/validate-profile will-profile-raw
+                                    :syntax?        false
+                                    :relations?     false
+                                    :concept-rels?  false
+                                    :template-rels? false
+                                    :pattern-rels?  true)
+                keys
+                set)
+           (->> (p/validate-profile-coll [will-profile-raw]
+                                         :syntax?        false
+                                         :relations?     false
+                                         :concept-rels?  false
+                                         :template-rels? false
+                                         :pattern-rels?  true)
+                first
+                keys
+                set)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Error message tests

--- a/src/test/com/yetanalytics/pan_test.cljc
+++ b/src/test/com/yetanalytics/pan_test.cljc
@@ -60,14 +60,14 @@
          (let [[correct-syntax? correct-ids? correct-graph? correct-ctxt?] res
                syntax-errs (p/validate-profile profile)
                id-errs     (p/validate-profile profile
-                                             :syntax? false
-                                             :ids? true)
+                                               :syntax? false
+                                               :ids? true)
                graph-errs  (p/validate-profile profile
-                                             :syntax? false
-                                             :relations? true)
+                                               :syntax? false
+                                               :relations? true)
                ctxt-errs   (p/validate-profile profile
-                                             :syntax? false
-                                             :context? true)]
+                                               :syntax? false
+                                               :context? true)]
            (if correct-syntax?
              (is (nil? syntax-errs))
              (is (some? syntax-errs)))
@@ -91,6 +91,57 @@
     ;; Fixed profiles (note that we can't completely fix cmi5 yet)
     "CATCH (fixed)" will-profile-fix [true true true true]
     "cmi5 (fixed)" cmi-profile-fix [true true false true]))
+
+(deftest relation-error-tests
+  (testing "Different relation keyword args"
+    (is (= #{:concept-edge-errors
+             :template-edge-errors
+             :pattern-edge-errors
+             :pattern-cycle-errors}
+           (->> (p/validate-profile will-profile-raw
+                                    :syntax?        false
+                                    :relations?     true
+                                    :concept-rels?  false
+                                    :template-rels? false
+                                    :pattern-rels?  false)
+                keys
+                set)
+           (->> (p/validate-profile will-profile-raw
+                                    :syntax?        false
+                                    :relations?     true
+                                    :concept-rels?  true
+                                    :template-rels? true
+                                    :pattern-rels?  true)
+                keys
+                set)))
+    (is (= #{:concept-edge-errors}
+           (->> (p/validate-profile will-profile-raw
+                                    :syntax?        false
+                                    :relations?     false
+                                    :concept-rels?  true
+                                    :template-rels? false
+                                    :pattern-rels?  false)
+                keys
+                set)))
+    (is (= #{:template-edge-errors}
+           (->> (p/validate-profile will-profile-raw
+                                    :syntax?        false
+                                    :relations?     false
+                                    :concept-rels?  false
+                                    :template-rels? true
+                                    :pattern-rels?  false)
+                keys
+                set)))
+    (is (= #{:pattern-edge-errors
+             :pattern-cycle-errors}
+           (->> (p/validate-profile will-profile-raw
+                                    :syntax?        false
+                                    :relations?     false
+                                    :concept-rels?  false
+                                    :template-rels? false
+                                    :pattern-rels?  true)
+                keys
+                set)))))
 
 (deftest catch-err-data-test
   (testing "the CATCH profile error data"


### PR DESCRIPTION
Each keyword arg, when `true` indicates validation only on Concept, Template, and Pattern relations, respectively. All three kwargs are default `false` and are overridden if `:relations?` is `true`.