### PR TITLE
IRI get rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The `get-iris-map` function is provided in the API in order to retrieve IRIs by 
  :context #{"http://example.com/resource-context"}
  :schema #{"http://example.com/json-schema"}}
 ```
+The `get-iris-map` function also accepts a `:iri-kind` keyword arg, which can be `:all`, `:internal`, or `:external` to set whether Profile-internal and/or external IRIs are returned.
 
 The `json-profile->edn` function is provided in the API to provide for convenient coercion of JSON profile strings into an EDN format that Pan recognizes.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,16 @@ Other keyword arguments include:
 
 The `validate-object` function is provided in order to provide a way to validate individual Concepts, Templates, and Patterns without having to go deeper than the top level API. The `:type` and `:result` keyword args are used to fix the expected spec and to affect the function result, respectively; more details can be found in the docstring.
 
-The `get-external-iris` function is provided in the API in order to retrieve IRI values that refer to external objects, JSON-LD contexts, etc. (i.e. objects that do _not_ exist in the Profile). This allows the user to more easily retrieve external Profiles and contexts in their application from the Internet or their data store.
+The `get-iris-map` function is provided in the API in order to retrieve IRIs by property, including JSON-LD context IRIs, which may link to objects that do _not_ exist in the Profile. This allows the user to more easily retrieve external Profiles and contexts in their application from the Internet or their data store. The following is a sample return value of `get-iris-map`; notice the `:kebab-type/camelProperty` format of each key, and how `:_context`, `:context`, and `:schema` are _not_ namespaced:
+```clojure
+{:verb/exactMatch #{"http://example.com/verb1"
+                    "http://example.com/verb2"}
+ :statement-template/verb #{"http://example.com/verb1"
+                            "http://example.com/verb2"}
+ :_context #{"http://example.com/jsonld-context"}
+ :context #{"http://example.com/resource-context"}
+ :schema #{"http://example.com/json-schema"}}
+```
 
 The `json-profile->edn` function is provided in the API to provide for convenient coercion of JSON profile strings into an EDN format that Pan recognizes.
 

--- a/src/main/com/yetanalytics/pan/objects/concepts/activity.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/activity.cljc
@@ -4,7 +4,8 @@
             [xapi-schema.spec]
             [com.yetanalytics.pan.axioms  :as ax]
             [com.yetanalytics.pan.context :as ctx]
-            [com.yetanalytics.pan.graph   :as graph]))
+            [com.yetanalytics.pan.graph   :as graph]
+            [com.yetanalytics.pan.objects.concepts.util :as cu]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Activity
@@ -65,3 +66,9 @@
 
 ;; Currently does nothing
 (defmethod graph/edges-with-attrs "Activity" [_] [])
+
+(defmethod cu/get-iris "Activity"
+  [activity]
+  (if-some [activity-type (get-in activity [:activityDefinition :type])]
+    {:activity/type [activity-type]}
+    {}))

--- a/src/main/com/yetanalytics/pan/objects/concepts/activity_type.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/activity_type.cljc
@@ -48,3 +48,20 @@
                     (map #(vector id % {:type :related}) related)
                     (map #(vector id % {:type :relatedMatch}) relatedMatch)
                     (map #(vector id % {:type :exactMatch}) exactMatch)))))
+
+(defmethod cu/get-iris "ActivityType"
+  [{:keys [broader
+           broadMatch
+           narrower
+           narrowMatch
+           related
+           relatedMatch
+           exactMatch]}]
+  (cond-> {}
+    broader      (assoc :activity-type/broader (set broader))
+    broadMatch   (assoc :activity-type/broadMatch (set broadMatch))
+    narrower     (assoc :activity-type/narrower (set narrower))
+    narrowMatch  (assoc :activity-type/narrowMatch (set narrowMatch))
+    related      (assoc :activity-type/related (set related))
+    relatedMatch (assoc :activity-type/relatedMatch (set relatedMatch))
+    exactMatch   (assoc :activity-type/exactMatch (set exactMatch))))

--- a/src/main/com/yetanalytics/pan/objects/concepts/attachment_usage_type.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/attachment_usage_type.cljc
@@ -48,3 +48,20 @@
                     (map #(vector id % {:type :related}) related)
                     (map #(vector id % {:type :relatedMatch}) relatedMatch)
                     (map #(vector id % {:type :exactMatch}) exactMatch)))))
+
+(defmethod cu/get-iris "AttachmentUsageType"
+  [{:keys [broader
+           broadMatch
+           narrower
+           narrowMatch
+           related
+           relatedMatch
+           exactMatch]}]
+  (cond-> {}
+    broader      (assoc :attachment-usage-type/broader (set broader))
+    broadMatch   (assoc :attachment-usage-type/broadMatch (set broadMatch))
+    narrower     (assoc :attachment-usage-type/narrower (set narrower))
+    narrowMatch  (assoc :attachment-usage-type/narrowMatch (set narrowMatch))
+    related      (assoc :attachment-usage-type/related (set related))
+    relatedMatch (assoc :attachment-usage-type/relatedMatch (set relatedMatch))
+    exactMatch   (assoc :attachment-usage-type/exactMatch (set exactMatch))))

--- a/src/main/com/yetanalytics/pan/objects/concepts/extensions/activity.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/extensions/activity.cljc
@@ -52,3 +52,14 @@
 
 ;; TODO: get string from iri
 ;; schema - json-schema string at other end of iri
+
+(defmethod cu/get-iris "ActivityExtension"
+  [{:keys [recommendedActivityTypes context schema]}]
+  (cond-> {}
+    recommendedActivityTypes
+    (assoc :activity-extension/recommendedActivityTypes
+           (set recommendedActivityTypes))
+    context
+    (assoc :context #{context})
+    schema
+    (assoc :schema #{schema})))

--- a/src/main/com/yetanalytics/pan/objects/concepts/extensions/context.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/extensions/context.cljc
@@ -51,3 +51,14 @@
 
 ;; TODO: get string from iri
 ;; schema - json-schema string at other end of iri
+
+(defmethod cu/get-iris "ContextExtension"
+  [{:keys [recommendedActivityTypes context schema]}]
+  (cond-> {}
+    recommendedActivityTypes
+    (assoc :context-extension/recommendedActivityTypes
+           (set recommendedActivityTypes))
+    context
+    (assoc :context #{context})
+    schema
+    (assoc :schema #{schema})))

--- a/src/main/com/yetanalytics/pan/objects/concepts/extensions/result.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/extensions/result.cljc
@@ -51,3 +51,14 @@
 
 ;; TODO: get string from iri
 ;; schema - json-schema string at other end of iri
+
+(defmethod cu/get-iris "ResultExtension"
+  [{:keys [recommendedVerbs context schema]}]
+  (cond-> {}
+    recommendedVerbs
+    (assoc :result-extension/recommendedVerbs
+           (set recommendedVerbs))
+    context
+    (assoc :context #{context})
+    schema
+    (assoc :schema #{schema})))

--- a/src/main/com/yetanalytics/pan/objects/concepts/resources/activity_profile.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/resources/activity_profile.cljc
@@ -48,3 +48,11 @@
 ;; TODO: LRS clients sending Document resources checks required by the spec
 ;; - id
 ;; - contentType
+
+(defmethod cu/get-iris "ActivityProfileResource"
+  [{:keys [context schema]}]
+  (cond-> {}
+    context
+    (assoc :context #{context})
+    schema
+    (assoc :schema #{schema})))

--- a/src/main/com/yetanalytics/pan/objects/concepts/resources/agent_profile.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/resources/agent_profile.cljc
@@ -48,3 +48,11 @@
 ;; TODO: LRS clients sending Document resources checks required by the spec
 ;; - id
 ;; - contentType
+
+(defmethod cu/get-iris "AgentProfileResource"
+  [{:keys [context schema]}]
+  (cond-> {}
+    context
+    (assoc :context #{context})
+    schema
+    (assoc :schema #{schema})))

--- a/src/main/com/yetanalytics/pan/objects/concepts/resources/state.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/resources/state.cljc
@@ -48,3 +48,11 @@
 ;; TODO: LRS clients sending Document resources checks required by the spec
 ;; - id
 ;; - contentType
+
+(defmethod cu/get-iris "StateResource"
+  [{:keys [context schema]}]
+  (cond-> {}
+    context
+    (assoc :context #{context})
+    schema
+    (assoc :schema #{schema})))

--- a/src/main/com/yetanalytics/pan/objects/concepts/util.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/util.cljc
@@ -17,3 +17,7 @@
       (true? deprecated)
       ;; Ignore if related property is not present
       true)))
+
+(defmulti get-iris
+  "Given an object, return a map of keys `:type/property` to IRI coll."
+  :type)

--- a/src/main/com/yetanalytics/pan/objects/concepts/verb.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/verb.cljc
@@ -48,3 +48,20 @@
                     (map #(vector id % {:type :related}) related)
                     (map #(vector id % {:type :relatedMatch}) relatedMatch)
                     (map #(vector id % {:type :exactMatch}) exactMatch)))))
+
+(defmethod cu/get-iris "Verb"
+  [{:keys [broader
+           broadMatch
+           narrower
+           narrowMatch
+           related
+           relatedMatch
+           exactMatch]}]
+  (cond-> {}
+    broader      (assoc :verb/broader (set broader))
+    broadMatch   (assoc :verb/broadMatch (set broadMatch))
+    narrower     (assoc :verb/narrower (set narrower))
+    narrowMatch  (assoc :verb/narrowMatch (set narrowMatch))
+    related      (assoc :verb/related (set related))
+    relatedMatch (assoc :verb/relatedMatch (set relatedMatch))
+    exactMatch   (assoc :verb/exactMatch (set exactMatch))))

--- a/src/main/com/yetanalytics/pan/utils/spec.cljc
+++ b/src/main/com/yetanalytics/pan/utils/spec.cljc
@@ -25,3 +25,15 @@
   (let [len1 (count v1) len2 (count v2)]
     (and (<= len1 len2)
          (= v1 (subvec v2 0 len1)))))
+
+
+(defn filter-map-set-values
+  "Given a map `m` with set values and a `filter-set`, filter each value
+   as `(filter-set-fn value filter-set)`."
+  [m filter-set filter-set-fn]
+  (reduce-kv (fn [m' k v]
+               (if-some [v' (not-empty (filter-set-fn v filter-set))]
+                 (assoc m' k v')
+                 m'))
+             {}
+             m))

--- a/src/test/com/yetanalytics/pan_test.cljc
+++ b/src/test/com/yetanalytics/pan_test.cljc
@@ -386,13 +386,16 @@
 ;; External IRI retrieval tests
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(deftest get-external-iri-test
-  (testing "get-external-iris function"
-    (is (= {:exactMatch
+(deftest get-iri-test
+  (testing "get-iris function"
+    (is (= {:verb/broader
+            #{"http://adlnet.gov/expapi/verbs/completed"}
+            :verb/exactMatch
+            #{"http://activitystrea.ms/schema/complete"
+              "http://activitystrea.ms/schema/terminate"}
+            :activity-type/exactMatch
             #{"https://w3id.org/xapi/profiles/ontology#Profile"
-              "https://w3id.org/xapi/cmi5/activities/course"
-              "http://activitystrea.ms/schema/terminate"
-              "http://activitystrea.ms/schema/complete"}
+              "https://w3id.org/xapi/cmi5/activities/course"}
             :context
             #{"https://raw.githubusercontent.com/adlnet/xAPI-SCORM-Profile/master/context/attempt-state-context.jsonld"}
             :schema
@@ -400,8 +403,83 @@
               "https://w3id.org/xapi/scorm/activity-profile/scorm.profile.activity.profile.schema"
               "https://raw.githubusercontent.com/adlnet/xAPI-SCORM-Profile/master/document-schemas/scorm.profile.attempt.state.schema.json"
               "https://raw.githubusercontent.com/adlnet/xAPI-SCORM-Profile/master/document-schemas/scorm.profile.activity.state.schema.json"}
-            :verb
+            :statement-template/verb
+            #{"http://adlnet.gov/expapi/verbs/resumed"
+              "http://adlnet.gov/expapi/verbs/suspended"
+              "http://adlnet.gov/expapi/verbs/completed"
+              "http://adlnet.gov/expapi/verbs/responded"
+              "http://adlnet.gov/expapi/verbs/initialized"
+              "http://adlnet.gov/expapi/verbs/terminated"
+              "http://adlnet.gov/expapi/verbs/commented"}
+            :statement-template/objectActivityType
+            #{"http://adlnet.gov/expapi/activities/lesson"
+              "http://adlnet.gov/expapi/activities/cmi.interaction"}
+            :pattern/sequence
+            #{"https://w3id.org/xapi/scorm#initialization"
+              "https://w3id.org/xapi/scorm#suspension"
+              "https://w3id.org/xapi/scorm#resumption"
+              "https://w3id.org/xapi/scorm#termination"
+              "https://w3id.org/xapi/scorm#middlestatements"
+              "https://w3id.org/xapi/scorm#optionallycontinue"}
+            :pattern/zeroOrMore
+            #{"https://w3id.org/xapi/scorm#suspendresume"
+              "https://w3id.org/xapi/scorm#activitystatements"}
+            :pattern/alternates
+            #{"https://w3id.org/xapi/scorm#commenting"
+              "https://w3id.org/xapi/scorm#otheractivity"
+              "https://w3id.org/xapi/scorm#interactionactivity"
+              "https://w3id.org/xapi/scorm#completing"
+              "https://w3id.org/xapi/scorm#scoactivity"}
+            ;; Bad value, ergo Pan splits it into chars
+            :statement-template/contextParentActivityType
+            #{\a \c \d \e \g \h \i \l \. \n \/ \o \p \s \t \v \x \:}}
+           (p/get-iris-map scorm-profile-raw)))
+    (is (= {:verb/exactMatch
+            #{"http://activitystrea.ms/schema/complete"
+              "http://activitystrea.ms/schema/terminate"}
+            :activity-type/exactMatch
+            #{"https://w3id.org/xapi/profiles/ontology#Profile"
+              "https://w3id.org/xapi/cmi5/activities/course"}
+            :context
+            #{"https://raw.githubusercontent.com/adlnet/xAPI-SCORM-Profile/master/context/attempt-state-context.jsonld"}
+            :schema
+            #{"https://raw.githubusercontent.com/adlnet/xAPI-SCORM-Profile/master/document-schemas/scorm.profile.agent.profile.schema.json"
+              "https://w3id.org/xapi/scorm/activity-profile/scorm.profile.activity.profile.schema"
+              "https://raw.githubusercontent.com/adlnet/xAPI-SCORM-Profile/master/document-schemas/scorm.profile.attempt.state.schema.json"
+              "https://raw.githubusercontent.com/adlnet/xAPI-SCORM-Profile/master/document-schemas/scorm.profile.activity.state.schema.json"}
+            :statement-template/verb
             #{"http://adlnet.gov/expapi/verbs/commented"}
-            :objectActivityType
-            #{"http://adlnet.gov/expapi/activities/cmi.interaction"}}
-           (p/get-external-iris scorm-profile-raw)))))
+            :statement-template/objectActivityType
+            #{"http://adlnet.gov/expapi/activities/cmi.interaction"}
+            ;; Bad value, ergo nothing can match
+            :statement-template/contextParentActivityType
+            #{\a \c \d \e \g \h \i \l \. \n \/ \o \p \s \t \v \x \:}}
+           (p/get-iris-map scorm-profile-raw :iri-kind :external)))
+    (is (= {:verb/broader
+            #{"http://adlnet.gov/expapi/verbs/completed"}
+            :statement-template/verb
+            #{"http://adlnet.gov/expapi/verbs/resumed"
+              "http://adlnet.gov/expapi/verbs/suspended"
+              "http://adlnet.gov/expapi/verbs/completed"
+              "http://adlnet.gov/expapi/verbs/responded"
+              "http://adlnet.gov/expapi/verbs/initialized"
+              "http://adlnet.gov/expapi/verbs/terminated"}
+            :statement-template/objectActivityType
+            #{"http://adlnet.gov/expapi/activities/lesson"}
+            :pattern/sequence
+            #{"https://w3id.org/xapi/scorm#initialization"
+              "https://w3id.org/xapi/scorm#suspension"
+              "https://w3id.org/xapi/scorm#resumption"
+              "https://w3id.org/xapi/scorm#termination"
+              "https://w3id.org/xapi/scorm#middlestatements"
+              "https://w3id.org/xapi/scorm#optionallycontinue"}
+            :pattern/zeroOrMore
+            #{"https://w3id.org/xapi/scorm#suspendresume"
+              "https://w3id.org/xapi/scorm#activitystatements"}
+            :pattern/alternates
+            #{"https://w3id.org/xapi/scorm#commenting"
+              "https://w3id.org/xapi/scorm#otheractivity"
+              "https://w3id.org/xapi/scorm#interactionactivity"
+              "https://w3id.org/xapi/scorm#completing"
+              "https://w3id.org/xapi/scorm#scoactivity"}}
+           (p/get-iris-map scorm-profile-raw :iri-kind :internal)))))


### PR DESCRIPTION
Rework `get-external-iris` into `get-iris-map`, which accepts a profile and returns a map that looks something like the following:
```clojure
{:verb/exactMatch #{"http://example.com/verb1"
                    "http://example.com/verb2"}
 :statement-template/verb #{"http://example.com/verb1"
                            "http://example.com/verb2"}
 :_context #{"http://example.com/jsonld-context"}
 :context #{"http://example.com/resource-context"}
 :schema #{"http://example.com/json-schema"}}
```
The `get-iris-map` function also accepts a `:iri-kind` keyword arg, which can be `:all`, `:internal`, or `:external`.

Much like #35, this PR was inspired by the needs of getting IRIs in a profile server backend.