### PR TITLE
[PAN-4] Limit versioning properties to Templates and Patterns

### DIFF
--- a/src/main/com/yetanalytics/pan/identifiers.cljc
+++ b/src/main/com/yetanalytics/pan/identifiers.cljc
@@ -207,17 +207,34 @@
 ;; - A Profile Author MUST change a Pattern's id between versions if any of
 ;;   alternates, optional, oneOrMore, sequence, or zeroOrMore change.
 ;;
-;; Also covers changes to Concept properties. TODO: Revist whether to keept this.
-;;
-;; TODO: Cover the following requiement:
-;; - If a Pattern used within another Pattern changes, the change will "bubble
-;;   up" as each id gets changed.
+;; TODO: Somehow validate the following Concept requirement:
+;; - A Profile MUST NOT define a Concept that is defined in another Profile
+;;   UNLESS it supersedes all versions of the other Profile containing the
+;;   Concept and indicates that in with wasRevisionOf.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn dissoc-properties
   "Dissoc properties that may change between version increments."
   [object]
-  (cond-> (dissoc object :inScheme :deprecated)
+  (cond-> (select-keys object [:id
+                               :type
+                               ;; StatementTemplate
+                               :verb
+                               :objectActivityType
+                               :contextCategoryActivityType
+                               :contextGroupingActivityType
+                               :contextParentActivityType
+                               :contextOtherActivityType
+                               :attachmentUsageType
+                               :objectStatementRefTemplate
+                               :contextStatementRefTemplate
+                               :rules
+                               ;; Patterns
+                               :alternates
+                               :sequence
+                               :optional
+                               :oneOrMore
+                               :zeroOrMore])
     (contains? object :rules)
     (update :rules (partial map #(dissoc % :scopeNote)))))
 

--- a/src/test/com/yetanalytics/pan/identifiers_test.cljc
+++ b/src/test/com/yetanalytics/pan/identifiers_test.cljc
@@ -87,8 +87,7 @@
 
 (deftest dissoc-properties-test
   (testing "dissoc-properties function"
-    (is (= {:id "https://w3id.org/catch/v2/some-verb"
-            :broader ["https://w3id.org/catch/a-verb"]}
+    (is (= {:id "https://w3id.org/catch/v2/some-verb"}
            (id/dissoc-properties
             {:id "https://w3id.org/catch/v2/some-verb"
              :inScheme "https://w3id.org/catch/v2"
@@ -495,32 +494,21 @@
                            {:id         "http://example.com/concept"
                             :inScheme   "http://example.com/v2"
                             :deprecated true}]})))
-    (let [spec-ed (id/validate-version-change
-                   {:id        "http://example.com"
-                    :versions [{:id "http://example.com/v1"}
-                               {:id "http://example.com/v2"}]
-                    :concepts [{:id       "http://example.com/concept"
-                                :inScheme "http://example.com/v1"
-                                :broader  ["http://example.org/concept-2"]}
-                               {:id       "http://example.com/concept"
-                                :inScheme "http://example.com/v2"
-                                :broader  ["http://example.org/concept-3"]}]
-                    :patterns [{:id       "http://example.com/pattern"
-                                :inScheme "http://example.com/v1"}
-                               {:id       "http://example.com/pattern"
-                                :inScheme "http://example.com/v2"}]})]
-      (is (some? spec-ed))
-      (is (= #{[{:id "http://example.com/concept",
-                 :inScheme "http://example.com/v1",
-                 :broader ["http://example.org/concept-2"]}
-                {:id "http://example.com/concept",
-                 :inScheme "http://example.com/v2",
-                 :broader ["http://example.org/concept-3"]}]
-               [{:id       "http://example.com/pattern"
-                 :inScheme "http://example.com/v1"}
-                {:id       "http://example.com/pattern"
-                 :inScheme "http://example.com/v2"}]}
-             (set (::s/value spec-ed)))))
+    (testing "- concept-specific changes are ignored"
+      (is (nil? (id/validate-version-change
+                 {:id        "http://example.com"
+                  :versions [{:id "http://example.com/v1"}
+                             {:id "http://example.com/v2"}]
+                  :concepts [{:id       "http://example.com/concept"
+                              :inScheme "http://example.com/v1"
+                              :broader  ["http://example.org/concept-2"]}
+                             {:id       "http://example.com/concept"
+                              :inScheme "http://example.com/v2"
+                              :broader  ["http://example.org/concept-3"]}]
+                  :patterns [{:id       "http://example.com/pattern"
+                              :inScheme "http://example.com/v1"}
+                             {:id       "http://example.com/pattern"
+                              :inScheme "http://example.com/v2"}]}))))
     (testing "- template-specific properties"
       (is (nil? (id/validate-version-change
                  {:id        "http://example.com"

--- a/src/test/com/yetanalytics/pan_test_fixtures.cljc
+++ b/src/test/com/yetanalytics/pan_test_fixtures.cljc
@@ -459,38 +459,109 @@ Detected 1 error
 -- Spec failed --------------------
 
 Objects:
-{:id \"https://w3id.org/xapi/video/extensions/video-playback-size\",
+{:id \"https://w3id.org/xapi/video/templates#paused\",
  :inScheme \"https://w3id.org/xapi/video/v1.0\",
- :type \"ContextExtension\",
+ :prefLabel {:en \"Paused\"},
+ :type \"StatementTemplate\",
  :definition
  {:en
-  \"Used to identify the size in Width x Height of the video as viewed by the user.\"},
- :prefLabel {:en \"video-playback-size\"},
- :inlineSchema \"{ \\\"type\\\": \\\"string\\\" }\"},
-{:id \"https://w3id.org/xapi/video/extensions/video-playback-size\",
+  \"The statement template and rules associated with a video being paused.\"},
+ :verb \"https://w3id.org/xapi/video/verbs/paused\",
+ :objectActivityType \"https://w3id.org/xapi/video/activity-type/video\",
+ :rules
+ [{:location
+   \"$.result.extensions['https://w3id.org/xapi/video/extensions/time']\",
+   :presence \"included\"}
+  {:location
+   \"$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']\",
+   :presence \"recommended\"}
+  {:location
+   \"$.result.extensions['https://w3id.org/xapi/video/extensions/progress']\",
+   :presence \"recommended\"}]},
+{:id \"https://w3id.org/xapi/video/templates#paused\",
  :inScheme \"https://w3id.org/xapi/video/v1.0.1\",
- :type \"ContextExtension\",
+ :prefLabel {:en \"Paused\"},
+ :type \"StatementTemplate\",
  :definition
  {:en
-  \"Used to identify the size in Width x Height of the video as viewed by the user.\"},
- :prefLabel {:en \"video-playback-size\"},
- :inlineSchema \"{ \\\"type\\\": \\\"string\\\" }\"},
-{:id \"https://w3id.org/xapi/video/extensions/video-playback-size\",
+  \"The statement template and rules associated with a video being paused.\"},
+ :verb \"https://w3id.org/xapi/video/verbs/paused\",
+ :objectActivityType \"https://w3id.org/xapi/video/activity-type/video\",
+ :rules
+ [{:location \"$.id\", :presence \"included\"}
+  {:location \"$.timestamp\", :presence \"included\"}
+  {:location
+   \"$.result.extensions['https://w3id.org/xapi/video/extensions/time']\",
+   :presence \"included\"}
+  {:location
+   \"$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']\",
+   :presence \"recommended\"}
+  {:location
+   \"$.result.extensions['https://w3id.org/xapi/video/extensions/progress']\",
+   :presence \"recommended\"}
+  {:location
+   \"$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']\",
+   :presence \"recommended\"}]},
+{:id \"https://w3id.org/xapi/video/templates#paused\",
  :inScheme \"https://w3id.org/xapi/video/v1.0.2\",
- :type \"ContextExtension\",
+ :prefLabel {:en \"Paused\"},
  :definition
  {:en
-  \"Used to identify the current video size in Width x Height as viewed by the user.\"},
- :prefLabel {:en \"video-playback-size\"},
- :inlineSchema \"{ \\\"type\\\": \\\"string\\\" }\"},
-{:id \"https://w3id.org/xapi/video/extensions/video-playback-size\",
+  \"The statement template and rules associated with a video being paused.\"},
+ :type \"StatementTemplate\",
+ :verb \"https://w3id.org/xapi/video/verbs/paused\",
+ :objectActivityType \"https://w3id.org/xapi/video/activity-type/video\",
+ :rules
+ [{:location \"$.id\", :presence \"included\"}
+  {:location \"$.timestamp\", :presence \"included\"}
+  {:location
+   \"$.context.extensions['https://w3id.org/xapi/video/extensions/length']\",
+   :presence \"included\"}
+  {:location
+   \"$.result.extensions['https://w3id.org/xapi/video/extensions/time']\",
+   :presence \"included\"}
+  {:location
+   \"$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']\",
+   :presence \"recommended\"}
+  {:location
+   \"$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']\",
+   :presence \"recommended\"}
+  {:location
+   \"$.result.extensions['https://w3id.org/xapi/video/extensions/progress']\",
+   :presence \"recommended\"}
+  {:location
+   \"$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']\",
+   :presence \"recommended\"}]},
+{:id \"https://w3id.org/xapi/video/templates#paused\",
  :inScheme \"https://w3id.org/xapi/video/v1.0.3\",
- :type \"ContextExtension\",
+ :prefLabel {:en \"Paused\"},
  :definition
  {:en
-  \"Used to identify the current video size in Width x Height as viewed by the user.\"},
- :prefLabel {:en \"video-playback-size\"},
- :inlineSchema \"{ \\\"type\\\": \\\"string\\\" }\"}
+  \"The statement template and rules associated with a video being paused.\"},
+ :type \"StatementTemplate\",
+ :verb \"https://w3id.org/xapi/video/verbs/paused\",
+ :objectActivityType \"https://w3id.org/xapi/video/activity-type/video\",
+ :rules
+ [{:location \"$.id\", :presence \"included\"}
+  {:location \"$.timestamp\", :presence \"included\"}
+  {:location
+   \"$.context.extensions['https://w3id.org/xapi/video/extensions/length']\",
+   :presence \"included\"}
+  {:location
+   \"$.result.extensions['https://w3id.org/xapi/video/extensions/time']\",
+   :presence \"included\"}
+  {:location
+   \"$.result.extensions['https://w3id.org/xapi/video/extensions/progress']\",
+   :presence \"included\"}
+  {:location
+   \"$.result.extensions['https://w3id.org/xapi/video/extensions/played-segments']\",
+   :presence \"included\"}
+  {:location
+   \"$.context.extensions['https://w3id.org/xapi/video/extensions/completion-threshold']\",
+   :presence \"recommended\"}
+  {:location
+   \"$.context.extensions['https://w3id.org/xapi/video/extensions/session-id']\",
+   :presence \"recommended\"}]}
 
 should not share the same ID if properties are changed
 


### PR DESCRIPTION
Limit properties that trigger a change in ID to Template and Pattern properties, as Concepts do not require ID changes when properties are changed according to the xAPI spec. Made as a separate PR in order to inspire discussion about this.