### PR TITLE
[PAN-5] Add value generation capabilities to profile specs

### DIFF
--- a/src/main/com/yetanalytics/pan/axioms.cljc
+++ b/src/main/com/yetanalytics/pan/axioms.cljc
@@ -67,8 +67,7 @@
 
 (s/def ::media-type
   (s/with-gen (s/and ::string media-type?)
-    (sgen/generate
-     (sgen/one-of
+    #(sgen/one-of
       [(sgen/fmap (partial str "application/")
                   (sgen/elements app-types))
        (sgen/fmap (partial str "audio/")
@@ -78,7 +77,7 @@
        (sgen/fmap (partial str "text/")
                   (sgen/elements txt-types))
        (sgen/fmap (partial str "video/")
-                  (sgen/elements vid-types))]))))
+                  (sgen/elements vid-types))])))
 
 ;; JSONPath strings
 ;; Example: "$.store.book"

--- a/src/main/com/yetanalytics/pan/axioms.cljc
+++ b/src/main/com/yetanalytics/pan/axioms.cljc
@@ -100,10 +100,10 @@
 
 (s/def ::json-path
   (s/with-gen (s/and string? json-path?)
-    (sgen/generate
-     (->> (sgen/vector (sgen/string-alphanumeric) 1 5)
+    #(->> (sgen/vector (sgen/string-alphanumeric) 1 5)
+          (sgen/fmap (partial filter not-empty))
           (sgen/fmap (partial cstr/join "."))
-          (sgen/fmap (partial str "$."))))))
+          (sgen/fmap (partial str "$.")))))
 
 ;; JSON Schema
 ;; Example: "{\"type\":\"array\", \"uniqueItems\":true}"

--- a/src/main/com/yetanalytics/pan/axioms.cljc
+++ b/src/main/com/yetanalytics/pan/axioms.cljc
@@ -5,7 +5,8 @@
             [xapi-schema.spec       :as xs]
             [xapi-schema.spec.regex :as xsr]
             [com.yetanalytics.pan.json-schema :as jsn-schema]
-            #?(:clj [clojure.data.json :as json]))
+            #?(:clj [clojure.data.json :as json]
+               :cljs [clojure.test.check.generators]))
   #?(:clj (:require
            [com.yetanalytics.pan.utils.resources :refer [read-edn-resource]])
      :cljs (:require-macros

--- a/src/main/com/yetanalytics/pan/context.cljc
+++ b/src/main/com/yetanalytics/pan/context.cljc
@@ -1,7 +1,9 @@
 (ns com.yetanalytics.pan.context
   (:require [clojure.spec.alpha          :as s]
+            [clojure.spec.gen.alpha      :as sgen]
             [clojure.string              :as cstr]
-            [com.yetanalytics.pan.axioms :as ax])
+            [com.yetanalytics.pan.axioms :as ax]
+            #?(:cljs [clojure.test.check.generators]))
   #?(:clj (:require [com.yetanalytics.pan.utils.resources
                      :refer [read-json-resource]])
      :cljs (:require-macros [com.yetanalytics.pan.utils.resources
@@ -36,7 +38,11 @@
 ;; Context Spec
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(s/def :context.term-def/_id (s/and string? (partial re-matches #".*:.*")))
+(s/def :context.term-def/_id
+  (s/with-gen (s/and string? (partial re-matches #".*:.*"))
+    #(sgen/fmap (fn [[pre post]] (str pre ":" post))
+                (sgen/tuple (sgen/string-ascii) (sgen/string-ascii)))))
+
 (s/def :context.term-def/_container #{"@list" "@set" "@language"})
 
 ;; Unimplemented context keyword specs, but kept here for reference

--- a/src/main/com/yetanalytics/pan/context.cljc
+++ b/src/main/com/yetanalytics/pan/context.cljc
@@ -2,8 +2,7 @@
   (:require [clojure.spec.alpha          :as s]
             [clojure.spec.gen.alpha      :as sgen]
             [clojure.string              :as cstr]
-            [com.yetanalytics.pan.axioms :as ax]
-            #?(:cljs [clojure.test.check.generators]))
+            [com.yetanalytics.pan.axioms :as ax])
   #?(:clj (:require [com.yetanalytics.pan.utils.resources
                      :refer [read-json-resource]])
      :cljs (:require-macros [com.yetanalytics.pan.utils.resources

--- a/src/main/com/yetanalytics/pan/json_schema.cljc
+++ b/src/main/com/yetanalytics/pan/json_schema.cljc
@@ -1,6 +1,9 @@
 (ns com.yetanalytics.pan.json-schema
   (:require [clojure.spec.alpha     :as s]
-            [xapi-schema.spec.regex :as xsr]))
+            [clojure.spec.gen.alpha :as sgen]
+            [xapi-schema.spec       :as xs]
+            [xapi-schema.spec.regex :as xsr]
+            #?(:cljs [clojure.test.check.generators])))
 
 ;; Based on the draft 7 meta-schema.
 ;; Most draft 6 schemas should be compatible as well, but future versions are
@@ -38,17 +41,20 @@
         fragment  (str "^#(?:" frag-char "|" fs "|" "\\?" ")*$")]
     (re-pattern fragment)))
 
-#_{:clj-kondo/ignore [:unresolved-var]}
 (def uri-reference-spec
-  (s/or :absolute-ref (partial re-matches xsr/AbsoluteURIRegEx)
-        :relative-ref (partial re-matches xsr/RelativeURLRegEx)
-        :same-doc-ref (partial re-matches (frag-spec))))
+  (s/with-gen
+   (s/and string?
+          (s/or :absolute-ref (partial re-matches xsr/AbsoluteURIRegEx)
+                :relative-ref (partial re-matches xsr/RelativeURLRegEx)
+                :same-doc-ref (partial re-matches (frag-spec))))
+    #(s/gen ::xs/iri)))
 
 ;; URI references
-(s/def ::$id (s/and string? uri-reference-spec)) ; Just "id" in draft 4)
-(s/def ::$ref (s/and string? uri-reference-spec))
-#_{:clj-kondo/ignore [:unresolved-var]}
-(s/def ::$schema (s/and string? (partial re-matches xsr/AbsoluteURIRegEx)))
+(s/def ::$id uri-reference-spec) ; Just "id" in draft 4)
+(s/def ::$ref uri-reference-spec)
+(s/def ::$schema
+  (s/with-gen (s/and string? (partial re-matches xsr/AbsoluteURIRegEx))
+    #(s/gen ::xs/iri)))
 
 (s/def ::$comment string?) ; Added in draft 7
 
@@ -71,7 +77,8 @@
 ;; Values and items
 (s/def ::pattern (s/and string? regex?))
 (s/def ::additionalItems ::schema)
-(s/def ::items (s/or :schema ::schema :array schema-array-spec))
+(s/def ::items (s/or :schema ::schema
+                     :array schema-array-spec))
 (s/def ::maxItems nat-int?)
 (s/def ::minItems nat-int?)
 (s/def ::uniqueItems boolean?)
@@ -82,21 +89,24 @@
 (s/def ::additionalProperties ::schema)
 
 ;; Maps
-(s/def ::definitions (s/map-of keyword? ::schema))
-(s/def ::properties (s/map-of keyword? ::schema))
+(s/def ::definitions (s/map-of keyword? ::schema :gen-max 5))
+(s/def ::properties (s/map-of keyword? ::schema :gen-max 5))
 (s/def ::patternProperties (s/map-of (s/and keyword?
                                             (s/conformer name)
                                             regex?)
-                                     ::schema))
+                                     ::schema
+                                     :gen-max 5))
 (s/def ::dependencies (s/map-of keyword?
                                 (s/or :schema ::schema
-                                      :string-array string-array-spec)))
+                                      :string-array string-array-spec)
+                                :gen-max 5))
 
 ;; More values
 (s/def ::propertyNames ::schema) ; Added in draft 6
 (s/def ::const any?) ; Added in draft 6
 (s/def ::enum enum-spec)
-(s/def ::type (s/or :string simple-types :array type-array-spec))
+(s/def ::type (s/or :string simple-types
+                    :array type-array-spec))
 (s/def ::format string?)
 
 ;; Content encoding - added in draft 7
@@ -113,49 +123,96 @@
 (s/def ::not ::schema)
 
 (s/def ::schema
-  (s/or :boolean boolean?
-        :object (s/keys :opt-un [::$id
-                                 ::$schema
-                                 ::$ref
-                                 ::$comment
-                                 ::title
-                                 ::description
-                                 ::default
-                                 ::readOnly
-                                 ::examples
-                                 ::multipleOf
-                                 ::maximum
-                                 ::exclusiveMaximum
-                                 ::minimum
-                                 ::exclusiveMinimum
-                                 ::maxLength
-                                 ::minLength
-                                 ::pattern
-                                 ::additionalItems
-                                 ::items
-                                 ::maxItems
-                                 ::minItems
-                                 ::uniqueItems
-                                 ::contains
-                                 ::maxProperties
-                                 ::minProperties
-                                 ::required
-                                 ::additionalProperties
-                                 ::definitions
-                                 ::properties
-                                 ::patternProperties
-                                 ::dependencies
-                                 ::propertyNames
-                                 ::const
-                                 ::enum
-                                 ::type
-                                 ::format
-                                 ::contentMediaType
-                                 ::contentEncoding
-                                 ::if
-                                 ::then
-                                 ::else
-                                 ::allOf
-                                 ::anyOf
-                                 ::oneOf
-                                 ::not])))
+  (s/with-gen
+    (s/or :boolean boolean?
+          :object (s/keys :opt-un [::$id
+                                   ::$schema
+                                   ::$ref
+                                   ::$comment
+                                   ::title
+                                   ::description
+                                   ::default
+                                   ::readOnly
+                                   ::examples
+                                   ::multipleOf
+                                   ::maximum
+                                   ::exclusiveMaximum
+                                   ::minimum
+                                   ::exclusiveMinimum
+                                   ::maxLength
+                                   ::minLength
+                                   ::pattern
+                                   ::additionalItems
+                                   ::items
+                                   ::maxItems
+                                   ::minItems
+                                   ::uniqueItems
+                                   ::contains
+                                   ::maxProperties
+                                   ::minProperties
+                                   ::required
+                                   ::additionalProperties
+                                   ::definitions
+                                   ::properties
+                                   ::patternProperties
+                                   ::dependencies
+                                   ::propertyNames
+                                   ::const
+                                   ::enum
+                                   ::type
+                                   ::format
+                                   ::contentMediaType
+                                   ::contentEncoding
+                                   ::if
+                                   ::then
+                                   ::else
+                                   ::allOf
+                                   ::anyOf
+                                   ::oneOf
+                                   ::not]))
+    ;; These generators don't generate all possible JSON schemas, but
+    ;; should be good enough for most purposes while not creating
+    ;; humongous schemas
+    #(sgen/one-of [;; string
+                   (sgen/fmap (fn [m] (assoc m :type "string"))
+                              (s/gen (s/keys :opt-un [::$id
+                                                      ::$schema
+                                                      ::minLength
+                                                      ::maxLength
+                                                      ::pattern
+                                                      ::format])))
+                   ;; numeric
+                   (sgen/fmap (fn [m] (assoc m :type "number"))
+                              (s/gen (s/keys :opt-un [::$id
+                                                      ::$schema
+                                                      ::multipleOf
+                                                      ::minimum
+                                                      ::maximum])))
+                   ;; boolean
+                   (sgen/fmap (fn [m] (assoc m :type "boolean"))
+                              (s/gen (s/keys :opt-un [::$id
+                                                      ::$schema])))
+                   ;; null
+                   (sgen/fmap (fn [m] (assoc m :type "null"))
+                              (s/gen (s/keys :opt-un [::$id
+                                                      ::$schema])))
+                   ;; object
+                   (sgen/fmap (fn [m] (assoc m :type "object"))
+                              (s/gen (s/keys :opt-un [::$id
+                                                      ::$schema
+                                                      ::properties
+                                                      ::patternProperties
+                                                      ::additionalProperties
+                                                      ::required])))
+                   ;; object (freeform)
+                   (sgen/fmap (fn [m] (assoc m :type "object"))
+                              (s/gen (s/keys :opt-un [::$id
+                                                      ::$schema
+                                                      ::propertyNames
+                                                      ::minProperties
+                                                      ::maxProperties])))
+                   ;; array
+                   (sgen/fmap (fn [m] (assoc m :type "array"))
+                              (s/gen (s/keys :opt-un [::$id
+                                                      ::$schema
+                                                      ::items])))])))

--- a/src/main/com/yetanalytics/pan/objects/concept.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concept.cljc
@@ -18,6 +18,20 @@
 ;; Concept Specs
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn valid-concept-type?
+  [{:keys [type]}]
+  (#{"Verb"
+     "Activity"
+     "ActivityType"
+     "AttachmentUsageType"
+     "ActivityExtension"
+     "ContextExtension"
+     "ResultExtension"
+     "ActivityProfileResource"
+     "AgentProfileResource"
+     "StateResource"}
+   type))
+
 (defmulti concept? :type)
 
 (defmethod concept? "Verb" [_] ::v/verb)
@@ -30,9 +44,14 @@
 (defmethod concept? "ActivityProfileResource" [_] ::acr/document-resource)
 (defmethod concept? "AgentProfileResource" [_] ::agr/document-resource)
 (defmethod concept? "StateResource" [_] ::sr/document-resource)
-(defmethod concept? :default [_] (constantly false))
 
-(s/def ::concept (s/multi-spec concept? :type))
+;; This weird arrangement is so that spec gen can be easily
+;; performed while preserving the correct error message
+(s/def ::concept
+  (s/with-gen (s/and valid-concept-type?
+                     (s/multi-spec concept? :type))
+    #(s/gen (s/and (s/multi-spec concept? :type)
+                   valid-concept-type?))))
 
 (s/def ::concepts (s/coll-of ::concept :type vector? :min-count 1))
 

--- a/src/main/com/yetanalytics/pan/objects/concepts/activity.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/activity.cljc
@@ -1,10 +1,12 @@
 (ns com.yetanalytics.pan.objects.concepts.activity
   (:require [clojure.spec.alpha :as s]
-            [clojure.walk :refer [stringify-keys]]
+            [clojure.spec.gen.alpha :as sgen]
+            [clojure.walk :refer [stringify-keys keywordize-keys]]
             [xapi-schema.spec]
             [com.yetanalytics.pan.axioms  :as ax]
             [com.yetanalytics.pan.context :as ctx]
-            [com.yetanalytics.pan.graph   :as graph]))
+            [com.yetanalytics.pan.graph   :as graph]
+            #?(:cljs [clojure.spec.test.alpha])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Activity
@@ -19,9 +21,13 @@
 (def context-url "https://w3id.org/xapi/profiles/activity-context")
 (s/def ::has-context-url (partial some #(= % context-url)))
 (s/def ::_context
-  (s/or :context-uri ::ax/uri
-        :context-array (s/and ::ax/array-of-uri
-                              ::has-context-url)))
+  (s/or :context-uri
+        ::ax/uri
+        :context-array
+        (s/with-gen (s/and ::ax/array-of-uri
+                           ::has-context-url)
+          #(->> (s/gen ::ax/array-of-uri)
+                (sgen/fmap (fn [v] (conj v context-url)))))))
 
 ;; Important to stringify lang maps to work with xapi-schema.
 ;; Top-level keys don't have to be stringified, however.
@@ -36,19 +42,26 @@
 (s/def ::extension
   (s/or :object (s/keys :req-un [::ctx/_context])
         :array  (s/coll-of (s/or :object (s/keys :req-un [::ctx/_context])
-                                 :non-object (comp not map?))
+                                 :non-object (s/and any? (comp not map?)))
                            :kind vector?)
-        :scalar (comp not coll?)))
+        :scalar (s/and any? (comp not coll?))))
 
 (s/def ::extensions
   (s/map-of ::ax/iri ::extension))
 
+(def activity-def-keys-spec
+  (s/keys :req-un [::_context]
+          :opt-un [::extensions]))
+
 (s/def ::activityDefinition
-  (s/and (s/nonconforming (s/keys :req-un [::_context]
-                                  :opt-un [::extensions]))
-         (s/conformer #(dissoc % :_context))
-         (s/conformer stringify-submaps)
-         :activity/definition))
+  (s/with-gen
+    (s/and (s/nonconforming activity-def-keys-spec)
+           (s/conformer #(dissoc % :_context))
+           (s/conformer stringify-submaps)
+           :activity/definition)
+   #(->> (sgen/tuple (s/gen :activity/definition)
+                     (s/gen activity-def-keys-spec))
+         (sgen/fmap (fn [[adef x]] (merge x (keywordize-keys adef)))))))
 
 (s/def ::activity
   (s/keys :req-un [::id ::type ::inScheme ::activityDefinition]

--- a/src/main/com/yetanalytics/pan/objects/concepts/activity.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/activity.cljc
@@ -5,8 +5,7 @@
             [xapi-schema.spec]
             [com.yetanalytics.pan.axioms  :as ax]
             [com.yetanalytics.pan.context :as ctx]
-            [com.yetanalytics.pan.graph   :as graph]
-            #?(:cljs [clojure.spec.test.alpha])))
+            [com.yetanalytics.pan.graph   :as graph]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Activity

--- a/src/main/com/yetanalytics/pan/objects/pattern.cljc
+++ b/src/main/com/yetanalytics/pan/objects/pattern.cljc
@@ -70,12 +70,14 @@
          ::pattern-clause
          ::is-primary-false))
 
-(defmulti pattern? #(:primary %))
+(defmulti pattern? :primary)
 (defmethod pattern? true [_] ::primary-pattern)
 (defmethod pattern? :default [_] ::non-primary-pattern)
 
 ;; Spec for a generic pattern.
-(s/def ::pattern (s/multi-spec pattern? #(:primary %)))
+;; The retag fn is so that both primary and non-primary patterns can be
+;; generated.
+(s/def ::pattern (s/multi-spec pattern? (fn [gen-v _] gen-v)))
 
 ;; Spec for a vector of patterns.
 (s/def ::patterns

--- a/src/main/com/yetanalytics/pan/objects/profile.cljc
+++ b/src/main/com/yetanalytics/pan/objects/profile.cljc
@@ -1,5 +1,6 @@
 (ns com.yetanalytics.pan.objects.profile
   (:require [clojure.spec.alpha          :as s]
+            [clojure.spec.gen.alpha      :as sgen]
             [com.yetanalytics.pan.axioms :as ax]
             [com.yetanalytics.pan.objects.profiles.version :as versions]
             [com.yetanalytics.pan.objects.profiles.author  :as author]
@@ -22,9 +23,13 @@
 (def context-url "https://w3id.org/xapi/profiles/context")
 (s/def ::has-context-url (partial some #(= context-url %)))
 (s/def ::_context
-  (s/or :context-iri ::ax/uri
-        :context-array (s/and ::ax/array-of-uri
-                              ::has-context-url)))
+  (s/or :context-iri
+        ::ax/uri
+        :context-array
+        (s/with-gen (s/and ::ax/array-of-uri
+                           ::has-context-url)
+          #(->> (s/gen ::ax/array-of-uri)
+                (sgen/fmap (fn [v] (conj v context-url)))))))
 
 (s/def ::profile
   (s/keys :req-un [::id ::_context ::type ::conformsTo ::prefLabel

--- a/src/main/com/yetanalytics/pan/objects/templates/rule.cljc
+++ b/src/main/com/yetanalytics/pan/objects/templates/rule.cljc
@@ -6,7 +6,10 @@
 ;; Rules 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(s/def ::value-array (s/coll-of any? :type vector? :min-count 1))
+(s/def ::value-array (s/coll-of some?
+                                :type vector?
+                                :min-count 1
+                                :gen-max 2))
 
 (s/def ::location ::ax/json-path)
 (s/def ::selector ::ax/json-path)

--- a/src/test/com/yetanalytics/pan/errors_test_fixtures.cljc
+++ b/src/test/com/yetanalytics/pan/errors_test_fixtures.cljc
@@ -256,7 +256,7 @@ should contain keys: :definition, :inScheme, :prefLabel
 | key         | spec                                       |
 |=============+============================================|
 | :definition | (map-of                                    |
-|             |  com.yetanalytics.pan.axioms/language-tag? |
+|             |  :com.yetanalytics.pan.axioms/language-tag |
 |             |  string?                                   |
 |             |  :min-count                                |
 |             |  1)                                        |
@@ -264,7 +264,7 @@ should contain keys: :definition, :inScheme, :prefLabel
 | :inScheme   | com.yetanalytics.pan.axioms/iri-str?       |
 |-------------+--------------------------------------------|
 | :prefLabel  | (map-of                                    |
-|             |  com.yetanalytics.pan.axioms/language-tag? |
+|             |  :com.yetanalytics.pan.axioms/language-tag |
 |             |  string?                                   |
 |             |  :min-count                                |
 |             |  1)                                        |
@@ -313,7 +313,7 @@ should contain keys: :definition, :inScheme, :prefLabel
 | key         | spec                                       |
 |=============+============================================|
 | :definition | (map-of                                    |
-|             |  com.yetanalytics.pan.axioms/language-tag? |
+|             |  :com.yetanalytics.pan.axioms/language-tag |
 |             |  string?                                   |
 |             |  :min-count                                |
 |             |  1)                                        |
@@ -321,7 +321,7 @@ should contain keys: :definition, :inScheme, :prefLabel
 | :inScheme   | com.yetanalytics.pan.axioms/iri-str?       |
 |-------------+--------------------------------------------|
 | :prefLabel  | (map-of                                    |
-|             |  com.yetanalytics.pan.axioms/language-tag? |
+|             |  :com.yetanalytics.pan.axioms/language-tag |
 |             |  string?                                   |
 |             |  :min-count                                |
 |             |  1)                                        |

--- a/src/test/com/yetanalytics/pan/objects/concept_test.cljc
+++ b/src/test/com/yetanalytics/pan/objects/concept_test.cljc
@@ -1,11 +1,19 @@
 (ns com.yetanalytics.pan.objects.concept-test
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.spec.alpha     :as s]
+            [clojure.spec.gen.alpha :as sgen]
             [loom.attr]
             [com.yetanalytics.pan.graph :as graph]
             [com.yetanalytics.pan.objects.concept :as concept]
             [com.yetanalytics.test-utils :refer [should-satisfy+]]))
 
 ;; TODO Add test for testing a complete vector of concepts
+
+(deftest generative-tests
+  (testing "Generated Concepts are always valid"
+    (dotimes [_ 60]
+      (s/valid? ::concept/concept
+                (sgen/generate (s/gen ::concept/concept))))))
 
 (def at-1->at-2-fix
   {:src          "https://foo.org/at1"

--- a/src/test/com/yetanalytics/pan/objects/pattern_test.cljc
+++ b/src/test/com/yetanalytics/pan/objects/pattern_test.cljc
@@ -1,6 +1,7 @@
 (ns com.yetanalytics.pan.objects.pattern-test
   (:require [clojure.test :refer [deftest is testing]]
-            [clojure.spec.alpha :as s]
+            [clojure.spec.alpha     :as s]
+            [clojure.spec.gen.alpha :as sgen]
             [com.yetanalytics.pan.graph :as graph]
             [com.yetanalytics.pan.objects.pattern :as pattern]
             [com.yetanalytics.test-utils :refer [should-satisfy
@@ -200,6 +201,12 @@
                         :inScheme "https://w3id.org/xapi/catch/v1"
                         :optional "https://w3id.org/xapi/catch/templates#one"
                         :zeroOrMore "https://w3id.org/xapi/catch/templates#two"})))))
+
+(deftest generative-tests
+  (testing "Generated Patterns are always valid"
+    (dotimes [_ 30]
+      (s/valid? ::pattern/pattern
+                (sgen/generate (s/gen ::pattern/pattern))))))
 
 ;; Graph tests
 

--- a/src/test/com/yetanalytics/pan/objects/profile_test.cljc
+++ b/src/test/com/yetanalytics/pan/objects/profile_test.cljc
@@ -1,6 +1,7 @@
 (ns com.yetanalytics.pan.objects.profile-test
   (:require [clojure.test :refer [deftest is testing]]
-            [clojure.spec.alpha :as s]
+            [clojure.spec.alpha     :as s]
+            [clojure.spec.gen.alpha :as sgen]
             [com.yetanalytics.pan.objects.profile :as profile]
             [com.yetanalytics.test-utils :refer [should-satisfy+]]))
 
@@ -66,3 +67,9 @@
                    :conformsTo "https://w3id.org/xapi/profiles#1.0"
                    :prefLabel {"en"
                                "Catch"}}))))
+
+(deftest generative-tests
+  (testing "Generated Profiles are always valid"
+    (dotimes [_ 5]
+      (s/valid? ::profile/profile
+                (sgen/generate (s/gen ::profile/profile))))))

--- a/src/test/com/yetanalytics/pan/objects/template_test.cljc
+++ b/src/test/com/yetanalytics/pan/objects/template_test.cljc
@@ -1,6 +1,7 @@
 (ns com.yetanalytics.pan.objects.template-test
   (:require [clojure.test :refer [deftest is testing]]
-            [clojure.spec.alpha :as s]
+            [clojure.spec.alpha     :as s]
+            [clojure.spec.gen.alpha :as sgen]
             [com.yetanalytics.pan.graph :as graph]
             [com.yetanalytics.pan.objects.template :as template]
             [com.yetanalytics.test-utils :refer [should-satisfy
@@ -165,6 +166,12 @@
                     :definition {"en" "A test of only the required properties
                                      for a template"}}]))
     (is (not (s/valid? ::template/templates [])))))
+
+(deftest generative-tests
+  (testing "Generated Statement Templates are always valid"
+    (dotimes [_ 30]
+      (s/valid? ::template/template
+                (sgen/generate (s/gen ::template/template))))))
 
 ;; Strict validation tests
 

--- a/src/test/com/yetanalytics/pan_test_fixtures.cljc
+++ b/src/test/com/yetanalytics/pan_test_fixtures.cljc
@@ -140,7 +140,7 @@ should contain key: :definition
 | key         | spec                                       |
 |=============+============================================|
 | :definition | (map-of                                    |
-|             |  com.yetanalytics.pan.axioms/language-tag? |
+|             |  :com.yetanalytics.pan.axioms/language-tag |
 |             |  string?                                   |
 |             |  :min-count                                |
 |             |  1)                                        |


### PR DESCRIPTION
All profile syntax specs (from axioms up until the whole profile spec) now have spec generation capabilities.

Additional changes noted:
- Rule `any`, `all`, and `none` values **can no longer be** `nil`.
- Minor changes to error string output