### PR TITLE
Activity spec changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## 0.5.2 - 2022-09-28
+- Decouple Pan's `::activityDefinition` spec from that of the xapi-schema lib.
+- Change the JSON parse function to not keywordize keys containing `:`.
+  - This change mainly affects IRIs, such as Activity extension keys.
+- Move all `clojure.test.check.generators` requires to test namespaces.
+  - Downstream cljs applications no longer have to include the `test.check` lib.
+
 ## 0.5.1 - 2022-07-21
 - Remove Loom dependency.
 - Add instrumentation to graph util functions.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Clojure library for validating xAPI Profiles, according to the [xAPI Profile s
 Add the following to the `:deps` map in your `deps.edn` file:
 
 ```clojure
-com.yetanalytics/project-pan {:mvn/version "0.5.1"
+com.yetanalytics/project-pan {:mvn/version "0.5.2"
                               :exclusions [org.clojure/clojure
                                            org.clojure/clojurescript]}
 ```

--- a/src/main/com/yetanalytics/pan/axioms.cljc
+++ b/src/main/com/yetanalytics/pan/axioms.cljc
@@ -5,8 +5,7 @@
             [xapi-schema.spec       :as xs]
             [xapi-schema.spec.regex :as xsr]
             [com.yetanalytics.pan.json-schema :as jsn-schema]
-            #?(:clj [clojure.data.json :as json]
-               :cljs [clojure.test.check.generators]))
+            #?(:clj [clojure.data.json :as json]))
   #?(:clj (:require
            [com.yetanalytics.pan.utils.resources :refer [read-edn-resource]])
      :cljs (:require-macros

--- a/src/main/com/yetanalytics/pan/errors.cljc
+++ b/src/main/com/yetanalytics/pan/errors.cljc
@@ -2,14 +2,17 @@
   (:require #?(:clj [clojure.core :refer [format]]
                :cljs [goog.string :as gstring]
                [goog.string.format :as format])
+            ;; Basic requires
             [clojure.spec.alpha :as s]
             [clojure.pprint     :as pprint]
             [clojure.string     :as cstr]
             [expound.alpha      :as exp]
+            ;; Generic specs
             [com.yetanalytics.pan.axioms      :as ax]
             [com.yetanalytics.pan.context     :as ctx]
             [com.yetanalytics.pan.identifiers :as id]
-            [com.yetanalytics.pan.graph :as graph]
+            [com.yetanalytics.pan.graph       :as graph]
+            ;; Object specs
             [com.yetanalytics.pan.objects.concept                      :as c]
             [com.yetanalytics.pan.objects.concepts.util                :as cu]
             [com.yetanalytics.pan.objects.concepts.extensions.activity :as ae]
@@ -56,12 +59,25 @@
   "should not use recommended activity type on a Context Extension")
 (exp/defmsg ::re/no-recommended-activity-types
   "should not use recommended activity type on a Result Extension")
+
 (exp/defmsg ::act/activityDefinition
   "should be a valid activity definition")
-(exp/defmsg ::adef/extensions
-  "should be valid Activity extensions")
+(exp/defmsg ::adef/correctResponsesPattern
+  "should be an array of strings")
+(exp/defmsg ::adef/choices
+  "should be an array of choies interaction components")
+(exp/defmsg ::adef/scale
+  "should be an array of scale interaction components")
+(exp/defmsg ::adef/source
+  "should be an array of source interaction components")
+(exp/defmsg ::adef/target
+  "should be an array of target interaction components")
+(exp/defmsg ::adef/steps
+  "should be an array of steps interaction components")
 (exp/defmsg ::adef/extension
   "should be a valid Activity extension")
+(exp/defmsg ::adef/extensions
+  "should be valid Activity extensions")
 
 (exp/defmsg ::t/type-or-reference
   "should not contain both objectActivityType and objectStatementRefTemplate")

--- a/src/main/com/yetanalytics/pan/errors.cljc
+++ b/src/main/com/yetanalytics/pan/errors.cljc
@@ -16,6 +16,7 @@
             [com.yetanalytics.pan.objects.concepts.extensions.context  :as ce]
             [com.yetanalytics.pan.objects.concepts.extensions.result   :as re]
             [com.yetanalytics.pan.objects.concepts.activity            :as act]
+            [com.yetanalytics.pan.objects.concepts.activity.definition :as adef]
             [com.yetanalytics.pan.objects.template                     :as t]
             [com.yetanalytics.pan.objects.templates.rule               :as r]
             [com.yetanalytics.pan.objects.pattern                      :as p]))
@@ -57,9 +58,9 @@
   "should not use recommended activity type on a Result Extension")
 (exp/defmsg ::act/activityDefinition
   "should be a valid activity definition")
-(exp/defmsg ::act/extensions
+(exp/defmsg ::adef/extensions
   "should be valid Activity extensions")
-(exp/defmsg ::act/extension
+(exp/defmsg ::adef/extension
   "should be a valid Activity extension")
 
 (exp/defmsg ::t/type-or-reference

--- a/src/main/com/yetanalytics/pan/json_schema.cljc
+++ b/src/main/com/yetanalytics/pan/json_schema.cljc
@@ -2,8 +2,7 @@
   (:require [clojure.spec.alpha     :as s]
             [clojure.spec.gen.alpha :as sgen]
             [xapi-schema.spec       :as xs]
-            [xapi-schema.spec.regex :as xsr]
-            #?(:cljs [clojure.test.check.generators])))
+            [xapi-schema.spec.regex :as xsr]))
 
 ;; Based on the draft 7 meta-schema.
 ;; Most draft 6 schemas should be compatible as well, but future versions are

--- a/src/main/com/yetanalytics/pan/objects/concepts/activity.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/activity.cljc
@@ -1,6 +1,5 @@
 (ns com.yetanalytics.pan.objects.concepts.activity
   (:require [clojure.spec.alpha          :as s]
-            [clojure.spec.gen.alpha      :as sgen]
             [com.yetanalytics.pan.axioms :as ax]
             [com.yetanalytics.pan.graph  :as graph]
             [com.yetanalytics.pan.objects.concepts.activity.definition :as adef]))
@@ -16,14 +15,6 @@
 
 (s/def ::activityDefinition
   (s/multi-spec adef/activity-definition-spec (fn [gen-val _] gen-val)))
-
-(comment 
-  (s/explain-data
-   ::activityDefinition
-   {:_context "https://w3id.org/xapi/profiles/activity-context"
-    :name {"fr" "9", "en" "u6Bl2K"}
-    :interactionType "likert"})
-  (sgen/generate (s/gen ::activityDefinition)))
 
 (s/def ::activity
   (s/keys :req-un [::id ::type ::inScheme ::activityDefinition]

--- a/src/main/com/yetanalytics/pan/objects/concepts/activity.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/activity.cljc
@@ -1,11 +1,9 @@
 (ns com.yetanalytics.pan.objects.concepts.activity
-  (:require [clojure.spec.alpha :as s]
-            [clojure.spec.gen.alpha :as sgen]
-            [clojure.walk :refer [stringify-keys keywordize-keys]]
-            [xapi-schema.spec]
-            [com.yetanalytics.pan.axioms  :as ax]
-            [com.yetanalytics.pan.context :as ctx]
-            [com.yetanalytics.pan.graph   :as graph]))
+  (:require [clojure.spec.alpha          :as s]
+            [clojure.spec.gen.alpha      :as sgen]
+            [com.yetanalytics.pan.axioms :as ax]
+            [com.yetanalytics.pan.graph  :as graph]
+            [com.yetanalytics.pan.objects.concepts.activity.definition :as adef]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Activity
@@ -16,51 +14,16 @@
 (s/def ::inScheme ::ax/iri)
 (s/def ::deprecated ::ax/boolean)
 
-;; @context validation
-(def context-url "https://w3id.org/xapi/profiles/activity-context")
-(s/def ::has-context-url (partial some #(= % context-url)))
-(s/def ::_context
-  (s/or :context-uri
-        ::ax/uri
-        :context-array
-        (s/with-gen (s/and ::ax/array-of-uri
-                           ::has-context-url)
-          #(->> (s/gen ::ax/array-of-uri)
-                (sgen/fmap (fn [v] (conj v context-url)))))))
-
-;; Important to stringify lang maps to work with xapi-schema.
-;; Top-level keys don't have to be stringified, however.
-(defn stringify-submaps
-  "Stringify keys in maps that exist below the top level, i.e.
-   `{:foo {:bar 1}}` becomes `{:foo {\"bar\" 1}}`."
-  [m]
-  (into {} (map (fn [[k v]] [k (stringify-keys v)]) m)))
-
-;; MUST include a JSON-LD @context in all top-level objects of extensions,
-;; or in every top-level object if array-valued.
-(s/def ::extension
-  (s/or :object (s/keys :req-un [::ctx/_context])
-        :array  (s/coll-of (s/or :object (s/keys :req-un [::ctx/_context])
-                                 :non-object (s/and any? (comp not map?)))
-                           :kind vector?)
-        :scalar (s/and any? (comp not coll?))))
-
-(s/def ::extensions
-  (s/map-of ::ax/iri ::extension))
-
-(def activity-def-keys-spec
-  (s/keys :req-un [::_context]
-          :opt-un [::extensions]))
-
 (s/def ::activityDefinition
-  (s/with-gen
-    (s/and (s/nonconforming activity-def-keys-spec)
-           (s/conformer #(dissoc % :_context))
-           (s/conformer stringify-submaps)
-           :activity/definition)
-   #(->> (sgen/tuple (s/gen :activity/definition)
-                     (s/gen activity-def-keys-spec))
-         (sgen/fmap (fn [[adef x]] (merge x (keywordize-keys adef)))))))
+  (s/multi-spec adef/activity-definition-spec (fn [gen-val _] gen-val)))
+
+(comment 
+  (s/explain-data
+   ::activityDefinition
+   {:_context "https://w3id.org/xapi/profiles/activity-context"
+    :name {"fr" "9", "en" "u6Bl2K"}
+    :interactionType "likert"})
+  (sgen/generate (s/gen ::activityDefinition)))
 
 (s/def ::activity
   (s/keys :req-un [::id ::type ::inScheme ::activityDefinition]

--- a/src/main/com/yetanalytics/pan/objects/concepts/activity/definition.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/activity/definition.cljc
@@ -1,0 +1,128 @@
+(ns com.yetanalytics.pan.objects.concepts.activity.definition
+  (:require [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as sgen]
+            [xapi-schema.spec :as xs]
+            [com.yetanalytics.pan.axioms  :as ax]
+            [com.yetanalytics.pan.context :as ctx]
+            [com.yetanalytics.pan.objects.concepts.activity.definition.interaction-type :as itype]))
+
+;; @context
+
+(def context-url "https://w3id.org/xapi/profiles/activity-context")
+
+(defn- has-context-url? [context-coll]
+  (some #(= context-url %) context-coll))
+
+(s/def ::_context
+  (s/or :context-uri
+        ::ax/uri
+        :context-array
+        (s/with-gen (s/and ::ax/array-of-uri has-context-url?)
+          #(->> (s/gen ::ax/array-of-uri)
+                (sgen/fmap (fn [v] (conj v context-url)))))))
+
+;; Basics
+
+(s/def ::name ::ax/language-map)
+(s/def ::description ::ax/language-map)
+(s/def ::type ::ax/iri)
+(s/def ::moreInfo ::ax/irl)
+
+;; Interaction Activities
+
+(s/def ::interactionType
+  #{"true-false" "choice" "fill-in" "long-fill-in" "matching" "performance"
+    "sequencing" "likert" "numeric" "other"})
+
+(s/def ::correctResponsesPattern
+  (s/coll-of string? :kind vector?))
+
+(s/def ::choices itype/interaction-component-coll-spec)
+(s/def ::scale itype/interaction-component-coll-spec)
+(s/def ::source itype/interaction-component-coll-spec)
+(s/def ::target itype/interaction-component-coll-spec)
+(s/def ::steps itype/interaction-component-coll-spec)
+
+;; Extensions
+
+;; MUST include a JSON-LD @context in all top-level objects of extensions,
+;; or in every top-level object if array-valued.
+(s/def ::extension
+  (s/or :object (s/keys :req-un [::ctx/_context])
+        :array  (s/coll-of (s/or :object (s/keys :req-un [::ctx/_context])
+                                 :non-object (s/and any? (comp not map?)))
+                           :kind vector?)
+        :scalar (s/and any? (comp not coll?))))
+
+(s/def ::extensions
+  (s/map-of ::ax/iri ::extension))
+
+;; Putting it all together
+
+(def base-activity-def-spec
+  "Map spec for keys shared by all activity definitions."
+  (s/keys :req-un [::_context]
+          :opt-un [::name
+                   ::description
+                   ::type
+                   ::moreInfo
+                   ::extensions]))
+
+(def base-activity-def-keys
+  "Coll of keys shared by all activity definitions."
+  [:_context
+   :name
+   :description
+   :type
+   :moreInfo
+   :extensions])
+
+(def itype-activity-def-spec
+  (s/merge base-activity-def-spec
+           (s/keys :req-un [::interactionType]
+                   :opt-un [::correctResponsesPattern])))
+
+(def itype-activity-def-keys
+  (into base-activity-def-keys
+        [:interactionType
+         :correctResponsesPattern]))
+
+(defmulti activity-definition-spec :interactionType)
+
+(defmethod activity-definition-spec nil [_]
+  (s/and base-activity-def-spec
+         (apply xs/restrict-keys base-activity-def-keys)))
+
+(defmethod activity-definition-spec "choice" [_]
+  (s/and (s/merge itype-activity-def-spec
+                  (s/keys :opt-un [::choices]))
+         (apply xs/restrict-keys
+                (into itype-activity-def-keys [:choices]))))
+
+(defmethod activity-definition-spec "sequencing" [_]
+  (s/and (s/merge itype-activity-def-spec
+                  (s/keys :opt-un [::choices]))
+         (apply xs/restrict-keys
+                (into itype-activity-def-keys [:choices]))))
+
+(defmethod activity-definition-spec "likert" [_]
+  (s/and (s/merge itype-activity-def-spec
+                  (s/keys :opt-un [::scale]))
+         (apply xs/restrict-keys
+                (into itype-activity-def-keys [:scale]))))
+
+(defmethod activity-definition-spec "matching" [_]
+  (s/and (s/merge itype-activity-def-spec
+                  (s/keys :opt-un [::source ::target]))
+         (apply xs/restrict-keys
+                (into itype-activity-def-keys [:source :target]))))
+
+(defmethod activity-definition-spec "performance" [_]
+  (s/and (s/merge itype-activity-def-spec
+                  (s/keys :opt-un [::steps]))
+         (apply xs/restrict-keys
+                (into itype-activity-def-keys [:steps]))))
+
+(defmethod activity-definition-spec :default [_]
+  (s/and itype-activity-def-spec
+         (apply xs/restrict-keys itype-activity-def-keys)))

--- a/src/main/com/yetanalytics/pan/objects/concepts/activity/definition.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/activity/definition.cljc
@@ -52,8 +52,27 @@
 
 ;; Extensions
 
-;; MUST include a JSON-LD @context in all top-level objects of extensions,
-;; or in every top-level object if array-valued.
+;; From the spec: MUST include a JSON-LD @context in all top-level objects of
+;; extensions, or in every top-level object if array-valued.
+
+;; In other words, this is what extension vals should look like IN PROFILES:
+;; {
+;;   "http://extension.com/": {
+;;     "@context": {"foo": {"@id": "http://extension.com/foo"}},
+;;     "foo": 123
+;;   }
+;; }
+;; The @context map is so that the key "foo" can expand into an IRI; otherwise
+;; the extension (and thus the Profile) cannot be considered valid JSON-LD.
+;;
+;; This is what the same extension would look like in a Statement:
+;; {
+;;   "http://extension.com/": {
+;;     "foo": 123
+;;   }
+;; }
+;; Note the lack of @context map here.
+
 (s/def ::extension
   (s/or :object (s/keys :req-un [::ctx/_context])
         :array  (s/coll-of (s/or :object (s/keys :req-un [::ctx/_context])

--- a/src/main/com/yetanalytics/pan/objects/concepts/activity/definition.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/activity/definition.cljc
@@ -6,6 +6,9 @@
             [com.yetanalytics.pan.context :as ctx]
             [com.yetanalytics.pan.objects.concepts.activity.definition.interaction-type :as itype]))
 
+;; Based off of the activityDefinition specs in xapi-schema:
+;; https://github.com/yetanalytics/xapi-schema/blob/master/src/xapi_schema/spec.cljc
+
 ;; @context
 
 (def context-url "https://w3id.org/xapi/profiles/activity-context")
@@ -34,8 +37,12 @@
   #{"true-false" "choice" "fill-in" "long-fill-in" "matching" "performance"
     "sequencing" "likert" "numeric" "other"})
 
+;; Technically there are additional requirements for each response string,
+;; depending on interactionType (e.g. for "true-false" the string has to
+;; either be "true" or "false") but since xapi-schema doesn't model these
+;; (quite complex) requirements we don't do it here either.
 (s/def ::correctResponsesPattern
-  (s/coll-of ::ax/string :kind vector?))
+  (s/coll-of ::ax/string :kind vector? :min-count 1))
 
 (s/def ::choices itype/interaction-component-coll-spec)
 (s/def ::scale itype/interaction-component-coll-spec)

--- a/src/main/com/yetanalytics/pan/objects/concepts/activity/definition.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/activity/definition.cljc
@@ -35,7 +35,7 @@
     "sequencing" "likert" "numeric" "other"})
 
 (s/def ::correctResponsesPattern
-  (s/coll-of string? :kind vector?))
+  (s/coll-of ::ax/string :kind vector?))
 
 (s/def ::choices itype/interaction-component-coll-spec)
 (s/def ::scale itype/interaction-component-coll-spec)

--- a/src/main/com/yetanalytics/pan/objects/concepts/activity/definition/interaction_type.cljc
+++ b/src/main/com/yetanalytics/pan/objects/concepts/activity/definition/interaction_type.cljc
@@ -1,0 +1,28 @@
+(ns com.yetanalytics.pan.objects.concepts.activity.definition.interaction-type
+  (:require [clojure.spec.alpha          :as s]
+            [clojure.spec.gen.alpha      :as sgen]
+            [xapi-schema.spec            :as xs]
+            [com.yetanalytics.pan.axioms :as ax]))
+
+(s/def ::id
+  ::ax/string)
+(s/def ::description
+  ::ax/language-map)
+
+(def interaction-component-spec
+  (s/and (s/keys :req-un [::id]
+                 :opt-un [::description])
+         (xs/restrict-keys :id :description)))
+
+(def interaction-component-coll-spec
+  (s/with-gen
+    (s/and (s/coll-of interaction-component-spec
+                      :kind vector?
+                      :into []
+                      :min-count 1)
+           ;; IDs must be distinct
+           (fn [icomps] (->> icomps (map :id) (apply distinct?))))
+    #(->> interaction-component-spec
+          s/gen
+          sgen/vector-distinct
+          sgen/not-empty)))

--- a/src/main/com/yetanalytics/pan/objects/templates/rule.cljc
+++ b/src/main/com/yetanalytics/pan/objects/templates/rule.cljc
@@ -6,6 +6,15 @@
 ;; Rules 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; The `some?` can be any JSON-able object. Note that if contains kv-pairs,
+;; then the keys must be expandable into IRIs (see below).
+
+;; The following MUST is validated during context validation:
+;;   A Profile Author MUST include the keys of any non-primitive objects in
+;;   `any`, `all`, and `none` in additional `@context` beyond the ones provided
+;;   by this specification.
+;; See the activity.definition spec for reasons why this must be the case.
+
 (s/def ::value-array (s/coll-of some?
                                 :type vector?
                                 :min-count 1
@@ -36,8 +45,3 @@
 
 (s/def ::rule
   (s/and ::rule-keys ::rule-keywords))
-
-;; The following MUST is validated during context validation:
-;; A Profile Author MUST include the keys of any non-primitive objects in `any`,
-;; `all`, and `none` in additional `@context` beyond the ones provided by
-;; this specification.

--- a/src/test/com/yetanalytics/pan/objects/concept_test.cljc
+++ b/src/test/com/yetanalytics/pan/objects/concept_test.cljc
@@ -4,7 +4,8 @@
             [com.yetanalytics.pan.graph :as graph]
             [com.yetanalytics.pan.objects.concept :as concept]
             [com.yetanalytics.test-utils :refer [should-satisfy+
-                                                 instrumentation-fixture]]))
+                                                 instrumentation-fixture]]
+            #?(:cljs [clojure.test.check.generators])))
 
 (use-fixtures :once instrumentation-fixture)
 

--- a/src/test/com/yetanalytics/pan/objects/concepts/activity_test.cljc
+++ b/src/test/com/yetanalytics/pan/objects/concepts/activity_test.cljc
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.spec.alpha :as s]
             [com.yetanalytics.pan.objects.concepts.activity :as a]
+            [com.yetanalytics.pan.objects.concepts.activity.definition :as adef]
             [com.yetanalytics.test-utils :refer [should-satisfy
                                                  should-satisfy+
                                                  should-not-satisfy]]))
@@ -17,25 +18,25 @@
 
 (deftest context-test
   (testing "@context property"
-    (should-satisfy ::a/_context
+    (should-satisfy ::adef/_context
                     "https://w3id.org/xapi/profiles/activity-context")
-    (should-satisfy ::a/_context "https://some-other-context")
-    (should-satisfy ::a/_context
+    (should-satisfy ::adef/_context "https://some-other-context")
+    (should-satisfy ::adef/_context
                     ["https://w3id.org/xapi/profiles/activity-context"])
-    (should-not-satisfy ::a/_context ["https://some-other-context"])
-    (should-not-satisfy ::a/_context "foo bar")))
+    (should-not-satisfy ::adef/_context ["https://some-other-context"])
+    (should-not-satisfy ::adef/_context "foo bar")))
 
-(deftest stringify-lang-keys-test
-  (testing "turning keys in the name and description language maps into strings"
-    (is (= {:_context "https://w3id.org/xapi/profiles/activity-context"
-            :name {"en" "Blah"}
-            :description {"en" "Blah Blah Blah"}
-            :type "https://w3id.org/xapi/catch/activitytypes/blah"}
-           (a/stringify-submaps
-            {:_context "https://w3id.org/xapi/profiles/activity-context"
-             :name {:en "Blah"}
-             :description {:en "Blah Blah Blah"}
-             :type "https://w3id.org/xapi/catch/activitytypes/blah"})))))
+;; (deftest stringify-lang-keys-test
+;;   (testing "turning keys in the name and description language maps into strings"
+;;     (is (= {:_context "https://w3id.org/xapi/profiles/activity-context"
+;;             :name {"en" "Blah"}
+;;             :description {"en" "Blah Blah Blah"}
+;;             :type "https://w3id.org/xapi/catch/activitytypes/blah"}
+;;            (a/stringify-submaps
+;;             {:_context "https://w3id.org/xapi/profiles/activity-context"
+;;              :name {:en "Blah"}
+;;              :description {:en "Blah Blah Blah"}
+;;              :type "https://w3id.org/xapi/catch/activitytypes/blah"})))))
 
 (deftest activity-definition
   (testing "activityDefinition property"
@@ -76,3 +77,26 @@
                     :name {:en "Cross Linguistic Connections"}
                     :description {"en" "The cross linguistic connections competency as described by the EPISD Dual Language Competency Framework"}
                     :type "https://w3id.org/xapi/catch/activitytypes/competency"}}))))
+
+(comment
+  (s/explain-data
+   ::a/activity
+   {:id "https://w3id.org/xapi/catch/activities/competency/cross-linguistic-connections"
+    :type "Activity"
+    :inScheme "https://w3id.org/xapi/catch/v1"
+    :activityDefinition
+    {:_context "https://w3id.org/xapi/profiles/activity-context"
+     :name {:en "Cross Linguistic Connections"}
+     :description {"en" "The cross linguistic connections competency as described by the EPISD Dual Language Competency Framework"}
+     :type "https://w3id.org/xapi/catch/activitytypes/competency"}})
+  
+  (get-in {:id "https://w3id.org/xapi/catch/activities/competency/cross-linguistic-connections"
+           :type "Activity"
+           :inScheme "https://w3id.org/xapi/catch/v1"
+           :activityDefinition
+           {:_context "https://w3id.org/xapi/profiles/activity-context"
+            :name {:en "Cross Linguistic Connections"}
+            :description {"en" "The cross linguistic connections competency as described by the EPISD Dual Language Competency Framework"}
+            :type "https://w3id.org/xapi/catch/activitytypes/competency"}}
+          [:activityDefinition :name])
+  )

--- a/src/test/com/yetanalytics/pan/objects/concepts/activity_test.cljc
+++ b/src/test/com/yetanalytics/pan/objects/concepts/activity_test.cljc
@@ -26,77 +26,152 @@
     (should-not-satisfy ::adef/_context ["https://some-other-context"])
     (should-not-satisfy ::adef/_context "foo bar")))
 
-;; (deftest stringify-lang-keys-test
-;;   (testing "turning keys in the name and description language maps into strings"
-;;     (is (= {:_context "https://w3id.org/xapi/profiles/activity-context"
-;;             :name {"en" "Blah"}
-;;             :description {"en" "Blah Blah Blah"}
-;;             :type "https://w3id.org/xapi/catch/activitytypes/blah"}
-;;            (a/stringify-submaps
-;;             {:_context "https://w3id.org/xapi/profiles/activity-context"
-;;              :name {:en "Blah"}
-;;              :description {:en "Blah Blah Blah"}
-;;              :type "https://w3id.org/xapi/catch/activitytypes/blah"})))))
+(def interaction-type
+  [{:id "itype-1" :description {:en-US "Interaction Type 1"}}
+   {:id "itype-2" :description {:en-US "Interaction Type 2"}}
+   {:id "itype-3" :description {:en-US "Interaction Type 3"}}])
 
-(deftest activity-definition
+(def bad-interaction-type
+  [{:id "itype-1" :description {:en-US "Interaction Type 1A"}}
+   {:id "itype-1" :description {:en-US "Interaction Type 1B"}}])
+
+(deftest activity-definition-property-test
+  (testing "activityDefinition"
+    (testing "name property"
+      (should-satisfy+ ::adef/name
+                       {:en "Foo"}
+                       :bad
+                       {:xyzz "Invalid"}))
+    (testing "description property"
+      (should-satisfy+ ::adef/description
+                       {:en "Foo"}
+                       :bad
+                       {:xyzz "Invalid"}))
+    (testing "type property"
+      (should-satisfy+ ::adef/type
+                       "http://foo.org/activity-type"
+                       :bad
+                       "123"
+                       123))
+    (testing "moreInfo property"
+      (should-satisfy+ ::adef/type
+                       "http://foo.org/more-info"
+                       :bad
+                       "123"
+                       123))
+    (testing "interactionType property"
+      (should-satisfy+ ::adef/interactionType
+                       "true-false"
+                       "choice"
+                       "fill-in"
+                       "long-fill-in"
+                       "matching"
+                       "performance"
+                       "sequencing"
+                       "likert"
+                       "numeric"
+                       "other"
+                       :bad
+                       "zoo-wee-mama"))
+    (testing "correctResponsesPattern property"
+      (should-satisfy+ ::adef/correctResponsesPattern
+                       ["true"]
+                       ["golf[,]tetris"]
+                       ["Bob's your uncle"]
+                       ["{case_matters=false}{lang=en}Some Interaction"]
+                       ["likert_3"]
+                       ["ben[.]3[,]chris[.]2[,]troy[.]4[,]freddie[.]1"]
+                       :bad
+                       []
+                       [123]))
+    (testing "interaction component properties - valid"
+      (should-satisfy ::adef/choices interaction-type)
+      (should-satisfy ::adef/scale interaction-type)
+      (should-satisfy ::adef/source interaction-type)
+      (should-satisfy ::adef/target interaction-type)
+      (should-satisfy ::adef/steps interaction-type))
+    (testing "interaction component properties - invalid"
+      (should-not-satisfy ::adef/choices bad-interaction-type)
+      (should-not-satisfy ::adef/scale bad-interaction-type)
+      (should-not-satisfy ::adef/source bad-interaction-type)
+      (should-not-satisfy ::adef/target bad-interaction-type)
+      (should-not-satisfy ::adef/steps bad-interaction-type))))
+
+(deftest activity-definition-test
   (testing "activityDefinition property"
-    (is (s/valid? ::a/activityDefinition
-                  {:_context "https://w3id.org/xapi/profiles/activity-context"
-                   :name {:en "Cross Linguistic Connections"}
-                   :description {"en" "The cross linguistic connections competency as described by the EPISD Dual Language Competency Framework"}
-                   :type "https://w3id.org/xapi/catch/activitytypes/competency"}))
+    (is (s/valid?
+         ::a/activityDefinition
+         {:_context    "https://w3id.org/xapi/profiles/activity-context"
+          :name        {:en "Cross Linguistic Connections"}
+          :description {"en" "The cross linguistic connections competency as described by the EPISD Dual Language Competency Framework"}
+          :type        "https://w3id.org/xapi/catch/activitytypes/competency"}))
+    (testing "depends on interactionType"
+      (is (s/valid?
+           ::a/activityDefinition
+           {:_context        "https://w3id.org/xapi/profiles/activity-context"
+            :interactionType "choice"
+            :choices         interaction-type}))
+      (is (s/valid?
+           ::a/activityDefinition
+           {:_context        "https://w3id.org/xapi/profiles/activity-context"
+            :interactionType "sequencing"
+            :choices         interaction-type}))
+      (is (s/valid?
+           ::a/activityDefinition
+           {:_context        "https://w3id.org/xapi/profiles/activity-context"
+            :interactionType "likert"
+            :scale           interaction-type}))
+      (is (s/valid?
+           ::a/activityDefinition
+           {:_context        "https://w3id.org/xapi/profiles/activity-context"
+            :interactionType "matching"
+            :source           interaction-type
+            :target           interaction-type}))
+      (is (s/valid?
+           ::a/activityDefinition
+           {:_context        "https://w3id.org/xapi/profiles/activity-context"
+            :interactionType "performance"
+            :steps           interaction-type}))
+      (is (not (s/valid?
+                ::a/activityDefinition
+                {:_context        "https://w3id.org/xapi/profiles/activity-context"
+                 :interactionType "true-false"
+                 :steps           interaction-type})))
+      (is (not (s/valid?
+                ::a/activityDefinition
+                {:_context "https://w3id.org/xapi/profiles/activity-context"
+                 :correctResponsesPattern ["foo" "bar"]}))))
     (testing "with extension object"
-      (is (s/valid? ::a/activityDefinition
-                    {:_context "https://w3id.org/xapi/profiles/activity-context"
-                     :name {:en "Cross Linguistic Connections"}
-                     :description {"en" "The cross linguistic connections competency as described by the EPISD Dual Language Competency Framework"}
-                     :type "https://w3id.org/xapi/catch/activitytypes/competency"
-                     :extensions {"http://foo.org/extension-1"
-                                  {:_context {:foo "http://foo.org/"
-                                              :display {:_id        "foo:display"
-                                                        :_container "@language"}}
-                                   :display {:en-US "My Extension"}}
-                                  "http://foo.org/extension-2" 2}}))
-      (is (not (s/valid? ::a/activityDefinition
-                         {:_context "https://w3id.org/xapi/profiles/activity-context"
-                          :name {:en "Cross Linguistic Connections"}
-                          :description {"en" "The cross linguistic connections competency as described by the EPISD Dual Language Competency Framework"}
-                          :type "https://w3id.org/xapi/catch/activitytypes/competency"
-                          :extensions {"http://foo.org/extension-1"
-                                       {:display {:en-US "My Extension"}}
-                                       "http://foo.org/extension-2" 2}}))))))
+      (is (s/valid?
+           ::a/activityDefinition
+           {:_context    "https://w3id.org/xapi/profiles/activity-context"
+            :name        {:en "Cross Linguistic Connections"}
+            :description {"en" "The cross linguistic connections competency as described by the EPISD Dual Language Competency Framework"}
+            :type        "https://w3id.org/xapi/catch/activitytypes/competency"
+            :extensions  {"http://foo.org/extension-1"
+                          {:_context {:foo     "http://foo.org/"
+                                      :display {:_id        "foo:display"
+                                                :_container "@language"}}
+                           :display  {:en-US "My Extension"}}
+                          "http://foo.org/extension-2" 2}}))
+      (is (not (s/valid?
+                ::a/activityDefinition
+                {:_context    "https://w3id.org/xapi/profiles/activity-context"
+                 :name        {:en "Cross Linguistic Connections"}
+                 :description {"en" "The cross linguistic connections competency as described by the EPISD Dual Language Competency Framework"}
+                 :type        "https://w3id.org/xapi/catch/activitytypes/competency"
+                 :extensions  {"http://foo.org/extension-1" {:display {:en-US "My Extension"}}
+                               "http://foo.org/extension-2" 2}}))))))
 
 (deftest activity-test
   (testing "Activity concept"
-    (is (s/valid? ::a/activity
-                  {:id "https://w3id.org/xapi/catch/activities/competency/cross-linguistic-connections"
-                   :type "Activity"
-                   :inScheme "https://w3id.org/xapi/catch/v1"
-                   :activityDefinition
-                   {:_context "https://w3id.org/xapi/profiles/activity-context"
-                    :name {:en "Cross Linguistic Connections"}
-                    :description {"en" "The cross linguistic connections competency as described by the EPISD Dual Language Competency Framework"}
-                    :type "https://w3id.org/xapi/catch/activitytypes/competency"}}))))
-
-(comment
-  (s/explain-data
-   ::a/activity
-   {:id "https://w3id.org/xapi/catch/activities/competency/cross-linguistic-connections"
-    :type "Activity"
-    :inScheme "https://w3id.org/xapi/catch/v1"
-    :activityDefinition
-    {:_context "https://w3id.org/xapi/profiles/activity-context"
-     :name {:en "Cross Linguistic Connections"}
-     :description {"en" "The cross linguistic connections competency as described by the EPISD Dual Language Competency Framework"}
-     :type "https://w3id.org/xapi/catch/activitytypes/competency"}})
-  
-  (get-in {:id "https://w3id.org/xapi/catch/activities/competency/cross-linguistic-connections"
-           :type "Activity"
-           :inScheme "https://w3id.org/xapi/catch/v1"
-           :activityDefinition
-           {:_context "https://w3id.org/xapi/profiles/activity-context"
-            :name {:en "Cross Linguistic Connections"}
-            :description {"en" "The cross linguistic connections competency as described by the EPISD Dual Language Competency Framework"}
-            :type "https://w3id.org/xapi/catch/activitytypes/competency"}}
-          [:activityDefinition :name])
-  )
+    (is (s/valid?
+         ::a/activity
+         {:id "https://w3id.org/xapi/catch/activities/competency/cross-linguistic-connections"
+          :type "Activity"
+          :inScheme "https://w3id.org/xapi/catch/v1"
+          :activityDefinition
+          {:_context "https://w3id.org/xapi/profiles/activity-context"
+           :name {:en "Cross Linguistic Connections"}
+           :description {"en" "The cross linguistic connections competency as described by the EPISD Dual Language Competency Framework"}
+           :type "https://w3id.org/xapi/catch/activitytypes/competency"}}))))

--- a/src/test/com/yetanalytics/pan/objects/pattern_test.cljc
+++ b/src/test/com/yetanalytics/pan/objects/pattern_test.cljc
@@ -6,7 +6,8 @@
             [com.yetanalytics.test-utils :refer [instrumentation-fixture
                                                  should-satisfy
                                                  should-satisfy+
-                                                 should-not-satisfy]]))
+                                                 should-not-satisfy]]
+            #?(:cljs [clojure.test.check.generators])))
 
 (use-fixtures :once instrumentation-fixture)
 

--- a/src/test/com/yetanalytics/pan/objects/profile_test.cljc
+++ b/src/test/com/yetanalytics/pan/objects/profile_test.cljc
@@ -3,7 +3,8 @@
             [clojure.spec.alpha :as s]
             [com.yetanalytics.pan.objects.profile :as profile]
             [com.yetanalytics.test-utils :refer [instrumentation-fixture
-                                                 should-satisfy+]]))
+                                                 should-satisfy+]]
+            #?(:cljs [clojure.test.check.generators])))
 
 (use-fixtures :once instrumentation-fixture)
 

--- a/src/test/com/yetanalytics/pan/objects/template_test.cljc
+++ b/src/test/com/yetanalytics/pan/objects/template_test.cljc
@@ -6,7 +6,8 @@
             [com.yetanalytics.test-utils :refer [instrumentation-fixture
                                                  should-satisfy
                                                  should-satisfy+
-                                                 should-not-satisfy]]))
+                                                 should-not-satisfy]]
+            #?(:cljs [clojure.test.check.generators])))
 
 (use-fixtures :once instrumentation-fixture)
 

--- a/src/test/com/yetanalytics/pan/utils/json_test.cljc
+++ b/src/test/com/yetanalytics/pan/utils/json_test.cljc
@@ -11,4 +11,6 @@
     (is (= {:_foo 1 :_bar {:_baz 2}}
            (json/convert-json "{\"@foo\" : 1, \"@bar\" : {\"@baz\" : 2}}" "_")))
     (is (= {:_foo 1 :_bar {:_baz 2}}
-           (json/convert-json "{\"@foo\" : 1, \"@bar\" : {\"@baz\" : 2}}")))))
+           (json/convert-json "{\"@foo\" : 1, \"@bar\" : {\"@baz\" : 2}}")))
+    (is (= {"http://foo.org" {"http://bar.com" 123}}
+           (json/convert-json "{\"http://foo.org\": {\"http://bar.com\": 123}}")))))


### PR DESCRIPTION
- Decouple Pan's `::activityDefinition` spec from that of xapi-schema; instead of calling the latter's specs, `activityDefinition` property specs are now defined in-lib like any other.
- Change the JSON parse function so that keys with `:` chars (such as IRIs) do not get keywordized, so that they work with extension IRI key specs.