### PR TITLE
Move `clojure.test.check.generators` requires to test namespaces

### DIFF
--- a/src/main/com/yetanalytics/pan/axioms.cljc
+++ b/src/main/com/yetanalytics/pan/axioms.cljc
@@ -5,8 +5,7 @@
             [xapi-schema.spec       :as xs]
             [xapi-schema.spec.regex :as xsr]
             [com.yetanalytics.pan.json-schema :as jsn-schema]
-            #?(:clj [clojure.data.json :as json]
-               :cljs [clojure.test.check.generators]))
+            #?(:clj [clojure.data.json :as json]))
   #?(:clj (:require
            [com.yetanalytics.pan.utils.resources :refer [read-edn-resource]])
      :cljs (:require-macros

--- a/src/main/com/yetanalytics/pan/json_schema.cljc
+++ b/src/main/com/yetanalytics/pan/json_schema.cljc
@@ -2,8 +2,7 @@
   (:require [clojure.spec.alpha     :as s]
             [clojure.spec.gen.alpha :as sgen]
             [xapi-schema.spec       :as xs]
-            [xapi-schema.spec.regex :as xsr]
-            #?(:cljs [clojure.test.check.generators])))
+            [xapi-schema.spec.regex :as xsr]))
 
 ;; Based on the draft 7 meta-schema.
 ;; Most draft 6 schemas should be compatible as well, but future versions are

--- a/src/test/com/yetanalytics/pan/objects/concept_test.cljc
+++ b/src/test/com/yetanalytics/pan/objects/concept_test.cljc
@@ -4,7 +4,8 @@
             [com.yetanalytics.pan.graph :as graph]
             [com.yetanalytics.pan.objects.concept :as concept]
             [com.yetanalytics.test-utils :refer [should-satisfy+
-                                                 instrumentation-fixture]]))
+                                                 instrumentation-fixture]]
+            #?(:cljs [clojure.test.check.generators])))
 
 (use-fixtures :once instrumentation-fixture)
 

--- a/src/test/com/yetanalytics/pan/objects/pattern_test.cljc
+++ b/src/test/com/yetanalytics/pan/objects/pattern_test.cljc
@@ -6,7 +6,8 @@
             [com.yetanalytics.test-utils :refer [instrumentation-fixture
                                                  should-satisfy
                                                  should-satisfy+
-                                                 should-not-satisfy]]))
+                                                 should-not-satisfy]]
+            #?(:cljs [clojure.test.check.generators])))
 
 (use-fixtures :once instrumentation-fixture)
 

--- a/src/test/com/yetanalytics/pan/objects/profile_test.cljc
+++ b/src/test/com/yetanalytics/pan/objects/profile_test.cljc
@@ -3,7 +3,8 @@
             [clojure.spec.alpha :as s]
             [com.yetanalytics.pan.objects.profile :as profile]
             [com.yetanalytics.test-utils :refer [instrumentation-fixture
-                                                 should-satisfy+]]))
+                                                 should-satisfy+]]
+            #?(:cljs [clojure.test.check.generators])))
 
 (use-fixtures :once instrumentation-fixture)
 

--- a/src/test/com/yetanalytics/pan/objects/template_test.cljc
+++ b/src/test/com/yetanalytics/pan/objects/template_test.cljc
@@ -6,7 +6,8 @@
             [com.yetanalytics.test-utils :refer [instrumentation-fixture
                                                  should-satisfy
                                                  should-satisfy+
-                                                 should-not-satisfy]]))
+                                                 should-not-satisfy]]
+            #?(:cljs [clojure.test.check.generators])))
 
 (use-fixtures :once instrumentation-fixture)
 


### PR DESCRIPTION
This is to address an issue where downstream cljs apps had to include `org.clojure/test.check` in their dependencies.